### PR TITLE
Update @polkadot/api@beta to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "yarn build && node dist/index.js"
   },
   "dependencies": {
-    "@polkadot/api": "^2.7.1",
+    "@polkadot/api": "^2.10.2-12",
     "@polkadot/util": "^4.1.1",
     "@polkadot/util-crypto": "^4.1.1",
     "filter-console": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -861,60 +861,74 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@polkadot/api-derive@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-2.7.1.tgz#d4927e2e9579074466da8613953fd460b1f33466"
-  integrity sha512-tQboJ7VgbHU2lMGxxbsWVZjzS5735cFQKRB036d7or1m4sgyD8cPWopPOo3jyytPmHfuYF0Ni44ZppQeapDxGg==
+"@polkadot/api-derive@2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-2.10.2-12.tgz#47a35f25a8345031c7241c5f94111c262108d362"
+  integrity sha512-02NFfTWCW9h3OachtcUvpwTneTOhkM7RM7evmuoKLZxeDsfaALuZPhEdE7e4BQhF5hL2aNT6Jpmq8q10z2kh8A==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/api" "2.7.1"
-    "@polkadot/rpc-core" "2.7.1"
-    "@polkadot/types" "2.7.1"
-    "@polkadot/util" "^4.1.1"
-    "@polkadot/util-crypto" "^4.1.1"
-    bn.js "^5.1.3"
+    "@polkadot/api" "2.10.2-12"
+    "@polkadot/rpc-core" "2.10.2-12"
+    "@polkadot/types" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
+    "@polkadot/util-crypto" "^4.2.2-12"
+    bn.js "^4.11.9"
     memoizee "^0.4.14"
     rxjs "^6.6.3"
 
-"@polkadot/api@2.7.1", "@polkadot/api@^2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-2.7.1.tgz#3eb0ae7eecd342a68a68ed6cf082d6c73d0b6281"
-  integrity sha512-xgaLsv/qRTjRfSvFBgm9h9+gXK5pYn2iqlWPndvYSM/IaUZWAQPVWL1uGnrEbEFjHvpi6Fe28wsw+QCM8rBxew==
+"@polkadot/api@2.10.2-12", "@polkadot/api@^2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/api/-/api-2.10.2-12.tgz#db048f18faa32b45e0c90bc3bca00e39dc4340f1"
+  integrity sha512-7M1GUFCiMwt+Yw0+bJO7xBBu+6IYSbYsceUwsbwjr2W8annF10mEv83nC2QgnLuBsd7LAlTuAK+YSYnq44mQEw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/api-derive" "2.7.1"
-    "@polkadot/keyring" "^4.1.1"
-    "@polkadot/metadata" "2.7.1"
-    "@polkadot/rpc-core" "2.7.1"
-    "@polkadot/rpc-provider" "2.7.1"
-    "@polkadot/types" "2.7.1"
-    "@polkadot/types-known" "2.7.1"
-    "@polkadot/util" "^4.1.1"
-    "@polkadot/util-crypto" "^4.1.1"
-    bn.js "^5.1.3"
+    "@polkadot/api-derive" "2.10.2-12"
+    "@polkadot/keyring" "^4.2.2-12"
+    "@polkadot/metadata" "2.10.2-12"
+    "@polkadot/rpc-core" "2.10.2-12"
+    "@polkadot/rpc-provider" "2.10.2-12"
+    "@polkadot/types" "2.10.2-12"
+    "@polkadot/types-known" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
+    "@polkadot/util-crypto" "^4.2.2-12"
+    bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
     rxjs "^6.6.3"
 
-"@polkadot/keyring@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-4.1.1.tgz#bc5e66a42df4146bb67581665afee637df7fba12"
-  integrity sha512-qKNdaqaohIFwarJEU9XIium5ObzbFCi4Y5cO4JmVfWf+hwcAkeVOEFcz/cGkpIVUQhEHDlvEEoqesd5c1+LC4A==
+"@polkadot/bytes-asmjs-crypto@^2.0.2-13":
+  version "2.0.2-13"
+  resolved "https://registry.yarnpkg.com/@polkadot/bytes-asmjs-crypto/-/bytes-asmjs-crypto-2.0.2-13.tgz#b9a035d4ba04ee717321fb6250c74379b1ae518a"
+  integrity sha512-zBQkxtS+gVhqz8lZXb6x79Ug294tFJf2hZYSqdRPK9+4YmDRgsLuBU7slNBHn2avYVWCB7/8tlpKPeUTiMd9eQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/util" "4.1.1"
-    "@polkadot/util-crypto" "4.1.1"
 
-"@polkadot/metadata@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-2.7.1.tgz#ad2daf41e2efc21c6c83b2a15469ac40ccb896e7"
-  integrity sha512-lrBYZApKW9iCrZjrfrcuVjM857YIHdmHwJa/Z6QgS7MTGR+8modEKBKs+4hoyMN+NumYAYrHBwzcE2B3mINDyA==
+"@polkadot/bytes-wasm-crypto@^2.0.2-13":
+  version "2.0.2-13"
+  resolved "https://registry.yarnpkg.com/@polkadot/bytes-wasm-crypto/-/bytes-wasm-crypto-2.0.2-13.tgz#91cf9704282c7f9c36796b6c4608139ec8db528f"
+  integrity sha512-7VD+CGUzruVCRs/8+3FEOv5YASzAqrXz960Zt1291XMcK4YNTxNcsDt3mPnRBMbaIMkGIzsIkor3pjchx5P/XQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "2.7.1"
-    "@polkadot/types-known" "2.7.1"
-    "@polkadot/util" "^4.1.1"
-    "@polkadot/util-crypto" "^4.1.1"
-    bn.js "^5.1.3"
+
+"@polkadot/keyring@^4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-4.2.2-12.tgz#b8d3d2e3c287029f7f2a661be8bb4198509b5343"
+  integrity sha512-6DIL3xQRfHVbA4mt6D9J1MRFouSfzVIJX1V8lAHFAm/LjnkEHv20alK7S0X5V62GLW+MrYNW+8cPezXHrKaOrg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/util" "4.2.2-12"
+    "@polkadot/util-crypto" "4.2.2-12"
+
+"@polkadot/metadata@2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-2.10.2-12.tgz#33c9b7872e483fca7d305e3c83c7ee86ff927b08"
+  integrity sha512-cFtvZRLncIdTTsm5V1ga5JDxclBL546s496l2oNuk0CM9XP5IE6KHpecnbVpZ3SZF2Gctd9evlPGvXKhg1R0vg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/types" "2.10.2-12"
+    "@polkadot/types-known" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
+    "@polkadot/util-crypto" "^4.2.2-12"
+    bn.js "^4.11.9"
 
 "@polkadot/networks@4.1.1":
   version "4.1.1"
@@ -923,58 +937,86 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/rpc-core@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-2.7.1.tgz#4a51f2099019faeaf8d710d02a7855ec58f3f378"
-  integrity sha512-5TA+EZ1sWDwgrfFoMc4SsEwHo9ivO/wfPZsxNixHw1wL68y+3G4pG1YLztcKF//Qp35nOz4JGyX+lNuU3BPXdw==
+"@polkadot/networks@4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/networks/-/networks-4.2.2-12.tgz#45391b02bfbafc39403a30ceb2d53008fd27f354"
+  integrity sha512-XKSLJa6yjAoCg+ZCHB6mhF4JpNcNZo7lrrJ0LZM1NtWM/COJg2Iu8H44iCqn+zYSoC1pL7Re+enSBftoDGsepg==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "2.7.1"
-    "@polkadot/rpc-provider" "2.7.1"
-    "@polkadot/types" "2.7.1"
-    "@polkadot/util" "^4.1.1"
+
+"@polkadot/rpc-core@2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-2.10.2-12.tgz#3bf5809641b20af377bc5f8445f12d0fd3dee1a6"
+  integrity sha512-lqJA45IIcbcFJJ4WM9ZWx0OeK5fpDB0jd4ZrPvRwyADb3gDMaz2V19mDdsf14wXQCV9wqSzXK1UnVngiyJ5YUg==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/metadata" "2.10.2-12"
+    "@polkadot/rpc-provider" "2.10.2-12"
+    "@polkadot/types" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
     memoizee "^0.4.14"
     rxjs "^6.6.3"
 
-"@polkadot/rpc-provider@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-2.7.1.tgz#dd2515648a70665ecd2b56adcc30e8804ed225d4"
-  integrity sha512-AOS9RfYm8aFuvYo1Bd/SX9eHQJlWbW9IYwNqHLOfXmLRxbIkfVzsc49tCsr+Zy1Ctt/d5bA86P5cUdH0LI0acg==
+"@polkadot/rpc-provider@2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-2.10.2-12.tgz#cfa7033deffc8be30b98e02495497b2f255523ea"
+  integrity sha512-X54HYvTRubTJFoCFWS+Sn0tGfSkzu6KHnDAqB3r9ez9T6CJ3Q/AHuDXZBSXN5jnYc5ZSLyhzbm7vjOsFi0LWtA==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "2.7.1"
-    "@polkadot/util" "^4.1.1"
-    "@polkadot/util-crypto" "^4.1.1"
-    "@polkadot/x-fetch" "^4.1.1"
-    "@polkadot/x-ws" "^4.1.1"
-    bn.js "^5.1.3"
+    "@polkadot/types" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
+    "@polkadot/util-crypto" "^4.2.2-12"
+    "@polkadot/x-fetch" "^4.2.2-12"
+    "@polkadot/x-ws" "^4.2.2-12"
+    bn.js "^4.11.9"
     eventemitter3 "^4.0.7"
 
-"@polkadot/types-known@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-2.7.1.tgz#bb6edef252a6ab83cf4088848d68fa56d004902c"
-  integrity sha512-cnrRJ7HV/ICWwoxNv0cKZZ5EVmPMOnLrcoC1SQYANkOjpxVdloxPdkr+1i6trPJhXntxwRvdFIYqKiAtsfMrGw==
+"@polkadot/types-known@2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-2.10.2-12.tgz#424bfc8e286acf17e60502f3ce404f226b2fe1b9"
+  integrity sha512-GZby6p9FGbhXA87rO14MWJWgM16PtQ9oLyCJBng9OeFtEYUm5orbDuCOdNmENWDcaqIO+4VKpIburbhMhrsfUQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/types" "2.7.1"
-    "@polkadot/util" "^4.1.1"
-    bn.js "^5.1.3"
+    "@polkadot/types" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
+    bn.js "^4.11.9"
 
-"@polkadot/types@2.7.1":
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-2.7.1.tgz#f3cac7bba7fa7d1d3d7bd3e474b4ef776526e82f"
-  integrity sha512-v7vHozNZxz+pSlQnjogtUwzsNU3E5sZ7+oQipFS/S2zXz2Q8K1QOUE08thZTqR5M4cyPDbbD5sHBaSNOMk5X1Q==
+"@polkadot/types@2.10.2-12":
+  version "2.10.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/types/-/types-2.10.2-12.tgz#691cb59a80007b3d1d49628f3459290ce9f96c1a"
+  integrity sha512-r28V8cypWBZCh7tn1aaNmvYUJGPHpwByTDyeorIOdUh9iIwOi3Tz0xCsDEah2MylXOG8e7UzTw7DB/OXeP1kkw==
   dependencies:
     "@babel/runtime" "^7.12.5"
-    "@polkadot/metadata" "2.7.1"
-    "@polkadot/util" "^4.1.1"
-    "@polkadot/util-crypto" "^4.1.1"
+    "@polkadot/metadata" "2.10.2-12"
+    "@polkadot/util" "^4.2.2-12"
+    "@polkadot/util-crypto" "^4.2.2-12"
     "@types/bn.js" "^4.11.6"
-    bn.js "^5.1.3"
+    bn.js "^4.11.9"
     memoizee "^0.4.14"
     rxjs "^6.6.3"
 
-"@polkadot/util-crypto@4.1.1", "@polkadot/util-crypto@^4.1.1":
+"@polkadot/util-crypto@4.2.2-12", "@polkadot/util-crypto@^4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-4.2.2-12.tgz#8c6e2f072d3a9fad9bafb247135ea8651090068b"
+  integrity sha512-QzL0d9VRaHNQROu8aLkxyBBfXjSWulkJKrbI9s0QyB2KhAjZVP5+vrxFPkg1p38Um1HgSGAJ8RThV/f5xNEvoA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/networks" "4.2.2-12"
+    "@polkadot/util" "4.2.2-12"
+    "@polkadot/wasm-crypto" "^2.0.2-12"
+    "@polkadot/x-randomvalues" "4.2.2-12"
+    base-x "^3.0.8"
+    blakejs "^1.1.0"
+    bn.js "^4.11.9"
+    create-hash "^1.2.0"
+    elliptic "^6.5.3"
+    hash.js "^1.1.7"
+    js-sha3 "^0.8.0"
+    scryptsy "^2.1.0"
+    tweetnacl "^1.0.3"
+    xxhashjs "^0.2.2"
+
+"@polkadot/util-crypto@^4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-4.1.1.tgz#b3f9a03c7ad785e72d7a777cdfd76193635f290a"
   integrity sha512-LuA75GZqT1Lpx+RwMljoqNl0lPrfyDt9hUByGhzHQ0OjcaOzrcrzsmDYqFgz0ec8dg9KpNcbZM9CMI7r7mZ9cg==
@@ -1008,15 +1050,37 @@
     camelcase "^5.3.1"
     ip-regex "^4.2.0"
 
+"@polkadot/util@4.2.2-12", "@polkadot/util@^4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/util/-/util-4.2.2-12.tgz#92c34064e9660bed240aef76206ad1cdac541536"
+  integrity sha512-l5092nmoTbhN5jK2LthQi54UGgpla3OK/3wdEbbLYjsTzAndsynUqWTjG40V6jQAjDVgHX5EqcJJ9SabllYWRQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/x-textdecoder" "4.2.2-12"
+    "@polkadot/x-textencoder" "4.2.2-12"
+    "@types/bn.js" "^4.11.6"
+    bn.js "^4.11.9"
+    camelcase "^5.3.1"
+    ip-regex "^4.2.0"
+
 "@polkadot/wasm-crypto@^2.0.1":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-2.0.1.tgz#cf7384385f832f6389520cc00e52a87fda6f29b6"
   integrity sha512-Vb0q4NToCRHXYJwhLWc4NTy77+n1dtJmkiE1tt8j1pmY4IJ4UL25yBxaS8NCS1LGqofdUYK1wwgrHiq5A78PFA==
 
-"@polkadot/x-fetch@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-4.1.1.tgz#b03083d926da42596fb01871f17912308a34529e"
-  integrity sha512-pja/3bVqppEh/c/Dv9fXTeVDpsRPr7Il8ADw8qyHKQzYhE3qfrcnje1XV78xiaeCwBJMXL33KbaI/Vs0hc/eSw==
+"@polkadot/wasm-crypto@^2.0.2-12":
+  version "2.0.2-13"
+  resolved "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-2.0.2-13.tgz#c61c0ef448d3b1f06d05699b62f72f3edd9e703e"
+  integrity sha512-o29erKUygCCeyP5cXXWa0Deca6xxoT5JB9LfMMEiVWk7r+UYvgzCLOeWuFdCuofRkQCCrTCltyRoOw9NixRt7A==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@polkadot/bytes-asmjs-crypto" "^2.0.2-13"
+    "@polkadot/bytes-wasm-crypto" "^2.0.2-13"
+
+"@polkadot/x-fetch@^4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-4.2.2-12.tgz#7e1dd34bbf3440fe47c85c63731554d818998db5"
+  integrity sha512-Xep1VhSq/4OUYdOpU76/s+bNW+TYHvFElp7oxxqJnWIAE8gA/9DdQ3jlJIprkWpBzPtKxvANMg+FHbfNpguSVQ==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/node-fetch" "^2.5.7"
@@ -1029,10 +1093,24 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
+"@polkadot/x-randomvalues@4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-4.2.2-12.tgz#d5ac36cab8c407d4e2dbbd146a820c6721e9201b"
+  integrity sha512-RBCXcO7IzvCSr5gObnV0AE7p/DAGQyJN3c1QhXCHFQVNyJKKIgnIMTqaCDTGA8wG2xjYrFDxqGIxNeKdTJY26g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 "@polkadot/x-textdecoder@4.1.1":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-4.1.1.tgz#9bdc94ca962b6f7d931c827e8316cd09fc751aff"
   integrity sha512-I0u3ymy2wAoi3zaycmBu8HqGudp4nMGKqSGasSB1ko9SKtB++JsWKH99it721rpeSdFXJOpBERQjvapCQXK6sQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@polkadot/x-textdecoder@4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-4.2.2-12.tgz#8365e405621720e7454c67dad57b56bc030d5e4f"
+  integrity sha512-ZZ9BoIy4EStH5Fl383NcDhAuN6L1g/CrS6LhjzdY/4EYzItezsiOuTTeGlJHIhyqawEK0iporOsMLYBM4UogBg==
   dependencies:
     "@babel/runtime" "^7.12.5"
 
@@ -1043,14 +1121,21 @@
   dependencies:
     "@babel/runtime" "^7.12.5"
 
-"@polkadot/x-ws@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-4.1.1.tgz#b5ba15d5f0cd36d1a8cc03c15d4ce661633c55be"
-  integrity sha512-SgNOgxOLsxCUC5g/G7j11rJfHuFkHR3LIMniB1GvkS87SWkbhftwPPgWOwdGOxxy2L3Ud7t4/4wnlUV+cmRcDA==
+"@polkadot/x-textencoder@4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-4.2.2-12.tgz#350f21586d0388e9ea736e15a1e39eca88cfaf8e"
+  integrity sha512-BJotqvPoJbbJ3myu3jgO7L+wAXluZaWgmtIxy29cqAVtdWjUrsWAwcQWsWheV6KDWTyITMyWaZEIWVHNEps1Aw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
+"@polkadot/x-ws@^4.2.2-12":
+  version "4.2.2-12"
+  resolved "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-4.2.2-12.tgz#55a584f2983bacf9e66756c0a3a41d0d6fea3b09"
+  integrity sha512-jGW6tORruuGxd+5hWU1HaZqNq9oSwsbxRviuLKPEKBrCc2IeKD6ZrIVb+exGyyWbCwmNF2WgsGUm4Hqio81mRA==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@types/websocket" "^1.0.1"
-    websocket "^1.0.32"
+    websocket "^1.0.33"
 
 "@types/bn.js@^4.11.6":
   version "4.11.6"
@@ -1201,7 +1286,7 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
-bn.js@^4.4.0:
+bn.js@^4.11.9, bn.js@^4.4.0:
   version "4.11.9"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.9.tgz#26d556829458f9d1e81fc48952493d0ba3507828"
   integrity sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==
@@ -2794,10 +2879,10 @@ util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
-websocket@^1.0.32:
-  version "1.0.32"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.32.tgz#1f16ddab3a21a2d929dec1687ab21cfdc6d3dbb1"
-  integrity sha512-i4yhcllSP4wrpoPMU2N0TQ/q0O94LRG/eUQjEAamRltjQ1oT1PFFKOG4i877OlJgCG8rw6LrrowJp+TYCEWF7Q==
+websocket@^1.0.33:
+  version "1.0.33"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
+  integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
   dependencies:
     bufferutil "^4.0.1"
     debug "^2.2.0"


### PR DESCRIPTION
This should solve a problem with

```
    createType(BlockWeights):: Cannot construct unknown type
BlockWeights
```

that is happening because polkadot node master (or rather substrate)
introduced some new types.