### PR TITLE
Updates for latest Polkadot master

### DIFF
--- a/src/spec.js
+++ b/src/spec.js
@@ -16,7 +16,7 @@ export function clearAuthorities(spec) {
 		console.error("failed to parse the chain spec");
 		process.exit(1);
 	}
-	chainSpec.genesis.runtime.palletSession.keys = [];
+	chainSpec.genesis.runtime.runtime_genesis_config.palletSession.keys = [];
 	let data = JSON.stringify(chainSpec, null, 2);
 	fs.writeFileSync(spec, data);
 	console.log(`Starting with a fresh authority set:`);
@@ -49,7 +49,7 @@ export async function addAuthority(spec, name) {
 
 	let rawdata = fs.readFileSync(spec);
 	let chainSpec = JSON.parse(rawdata);
-	chainSpec.genesis.runtime.palletSession.keys.push(key);
+	chainSpec.genesis.runtime.runtime_genesis_config.palletSession.keys.push(key);
 	let data = JSON.stringify(chainSpec, null, 2);
 	fs.writeFileSync(spec, data);
 	console.log(`Added Authority ${name}`);


### PR DESCRIPTION
The location of genesis config in the chainspec has changed in the latest Polkadot master:

https://github.com/paritytech/polkadot/blob/master/node/service/src/chain_spec.rs#L92