### PR TITLE
Improved manipulation of authority keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 ## Install
 
+```
+yarn global add polkadot-launch
+```
+
+Or, if you use `npm`:
 ```bash
 npm i polkadot-launch -g
 ```
@@ -134,8 +139,8 @@ These steps can be done for you automatically by running:
 yarn start
 ```
 
-When you have finished your changes, make a [pull request](https://github.com/shawntabrizi/polkadot-launch/pulls) to this repo.
+When you have finished your changes, make a [pull request](https://github.com/paritytech/polkadot-launch/pulls) to this repo.
 
 ## Get Help
 
-Open an [issue](https://github.com/shawntabrizi/polkadot-launch/issues) if you have problems or feature requests!
+Open an [issue](https://github.com/paritytech/polkadot-launch/issues) if you have problems or feature requests!

--- a/src/spec.js
+++ b/src/spec.js
@@ -6,6 +6,13 @@ function nameCase(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+function getAuthorityKeys(chainSpec) {
+	if (chainSpec.genesis.runtime.runtime_genesis_config) {
+		return chainSpec.genesis.runtime.runtime_genesis_config.palletSession.keys;
+	}
+	return chainSpec.genesis.runtime.palletSession.keys;
+}
+
 // Remove all existing keys from `session.keys`
 export function clearAuthorities(spec) {
 	let rawdata = fs.readFileSync(spec);
@@ -16,7 +23,10 @@ export function clearAuthorities(spec) {
 		console.error("failed to parse the chain spec");
 		process.exit(1);
 	}
-	chainSpec.genesis.runtime.runtime_genesis_config.palletSession.keys = [];
+
+	let keys = getAuthorityKeys(chainSpec)
+	keys.length = 0
+
 	let data = JSON.stringify(chainSpec, null, 2);
 	fs.writeFileSync(spec, data);
 	console.log(`Starting with a fresh authority set:`);
@@ -49,7 +59,10 @@ export async function addAuthority(spec, name) {
 
 	let rawdata = fs.readFileSync(spec);
 	let chainSpec = JSON.parse(rawdata);
-	chainSpec.genesis.runtime.runtime_genesis_config.palletSession.keys.push(key);
+
+	let keys = getAuthorityKeys(chainSpec)
+	keys.push(key)
+
 	let data = JSON.stringify(chainSpec, null, 2);
 	fs.writeFileSync(spec, data);
 	console.log(`Added Authority ${name}`);

--- a/src/spec.js
+++ b/src/spec.js
@@ -6,6 +6,7 @@ function nameCase(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+// Get authority keys from within chainSpec data
 function getAuthorityKeys(chainSpec) {
 	if (chainSpec.genesis.runtime.runtime_genesis_config) {
 		return chainSpec.genesis.runtime.runtime_genesis_config.palletSession.keys;
@@ -24,8 +25,8 @@ export function clearAuthorities(spec) {
 		process.exit(1);
 	}
 
-	let keys = getAuthorityKeys(chainSpec)
-	keys.length = 0
+	let keys = getAuthorityKeys(chainSpec);
+	keys.length = 0;
 
 	let data = JSON.stringify(chainSpec, null, 2);
 	fs.writeFileSync(spec, data);
@@ -60,8 +61,8 @@ export async function addAuthority(spec, name) {
 	let rawdata = fs.readFileSync(spec);
 	let chainSpec = JSON.parse(rawdata);
 
-	let keys = getAuthorityKeys(chainSpec)
-	keys.push(key)
+	let keys = getAuthorityKeys(chainSpec);
+	keys.push(key);
 
 	let data = JSON.stringify(chainSpec, null, 2);
 	fs.writeFileSync(spec, data);


### PR DESCRIPTION
This is a follow-up for https://github.com/paritytech/polkadot-launch/pull/39, for more robust manipulation of authority keys.

I tested the new code using chainspecs for `rococo-local` and `kusama-local`. The latter chainspec does not have the new `runtime_genesis_config` hierarchy, and the key manipulation code in this PR was still able to modify keys.

As for integration testing, with these changes and the `rococo-local` chainspec, the relay chain produced blocks successfully:
```
2021-01-05 05:59:36  🔖 Pre-sealed block for proposal at 12. Hash now 0xde428aa67343f0e84982badb63d565f1b2ad82156ffdb58107fc0888501ab8a0, previously 0x8d2b1bc199ccb0095021c7cdda513ec6e8f946de46883a0a952549dbedb13944.
2021-01-05 05:59:36  ✨ Imported #12 (0xde42…b8a0)
2021-01-05 05:59:36  💤 Idle (3 peers), best: #12 (0xde42…b8a0), finalized #9 (0xeabc…332c), ⬇ 21.8kiB/s ⬆ 29.5kiB/s
```
