### PR TITLE
Increase wasm file size limit.

### DIFF
--- a/src/spawn.js
+++ b/src/spawn.js
@@ -98,7 +98,7 @@ export async function exportGenesisWasm(bin, chain) {
 
 	// wasm files are typically large and `exec` requires us to supply the maximum buffer size in
 	// advance. Hopefully, this generous limit will be enough.
-	let opts = { maxBuffer: 5 * 1024 * 1024 }
+	let opts = { maxBuffer: 10 * 1024 * 1024 }
 	let { stdout, stderr } = await execFile(bin, args, opts)
 	if (stderr) {
 		console.error(stderr)


### PR DESCRIPTION
Acala wasm file exceeds 5M.