### PR TITLE
Use definition of struct CandidateDescriptor in primitives V1

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,9 +67,10 @@
 		"CandidateDescriptor": {
 			"para_id": "u32",
 			"relay_parent": "Hash",
-			"collator_id": "Hash",
+			"collator": "Hash",
 			"persisted_validation_data_hash": "Hash",
 			"pov_hash": "Hash",
+			"erasure_root": "Hash",
 			"signature": "Signature"
 		},
 		"CandidateReceipt": {


### PR DESCRIPTION
With amost latest polkadot master branch, when use https://polkadot.js.org connect local polkadot netowrk, i got error:

```sh
RPC-CORE: Unable to decode storage system.events: entry 0: createType(Vec<EventRecord>):: Struct: failed on data:
({"descriptor":"CandidateDescriptor","commitments_hash":"Hash"},Bytes):: Bytes: 
required length less than remainder, expected at least 11985, found 519
```

Use definition of struct CandidateDescriptor in primitives V1 solved this error. So i think we may need update this definition in config.json