### PR TITLE
Custom Genesis Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ These variable are fed directly into the Polkadot binary and used to spawn a nod
     --<name> \
 ```
 
-An example of `config` is:
+An example of `runtime_genesis_config` is:
 
 ```json
 "runtime_genesis_config": {

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ You can see an example [here](config.json).
   - `name`: Must be one of `alice`, `bob`, `charlie`, or `dave`.
   - `wsPort`: The websocket port for this node.
   - `port`: The TCP port for this node.
-- `config`: A JSON object of the properties you want to modify from
-  `parachainsConfiguration.config`. Non-specified properties will be unchanged from the original
-  genesis configuration.
+- `runtime_genesis_config`: A JSON object of the properties you want to modify from the genesis
+  configuration. Non-specified properties will be unchanged from the original genesis configuration.
 
 These variable are fed directly into the Polkadot binary and used to spawn a node:
 
@@ -75,15 +74,24 @@ These variable are fed directly into the Polkadot binary and used to spawn a nod
 An example of `config` is:
 
 ```json
-"config": {
-  "validation_upgrade_frequency": 1,
-  "validation_upgrade_delay": 1
+"runtime_genesis_config": {
+  "parachainsConfiguration": {
+    "config": {
+      "validation_upgrade_frequency": 1,
+      "validation_upgrade_delay": 1
+    }
+  },
+  "palletCollective": {
+    "members": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6"]
+  }
 }
 ```
 
-All `config` properties can be found in the
-[`HostConfiguration`](https://github.com/paritytech/polkadot/blob/master/runtime/parachains/src/configuration.rs)
-of the parachains runtime.
+All `runtime_genesis_config` properties can be found in the chainspec output:
+
+```bash
+./polkadot build-spec --chain=rococo-local --disable-default-bootnode
+```
 
 #### `parachains`
 

--- a/config.json
+++ b/config.json
@@ -24,9 +24,13 @@
 				"port": 30777
 			}
 		],
-		"config": {
-			"validation_upgrade_frequency": 1,
-			"validation_upgrade_delay": 1
+		"runtime_genesis_config": {
+			"parachainsConfiguration": {
+				"config": {
+					"validation_upgrade_frequency": 1,
+					"validation_upgrade_delay": 1
+				}
+			}
 		}
 	},
 	"parachains": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { checkConfig } from "./check";
 import {
 	clearAuthorities,
 	addAuthority,
-	changeGenesisParachainsConfiguration,
+	changeGenesisConfig,
 	addGenesisParachain,
 } from "./spec";
 import { parachainAccount } from "./parachain";
@@ -84,10 +84,10 @@ async function main() {
 	for (const node of config.relaychain.nodes) {
 		await addAuthority(`${chain}.json`, node.name);
 	}
-	if (config.relaychain.config) {
-		await changeGenesisParachainsConfiguration(
+	if (config.relaychain.runtime_genesis_config) {
+		await changeGenesisConfig(
 			`${chain}.json`,
-			config.relaychain.config
+			config.relaychain.runtime_genesis_config
 		);
 	}
 	await addParachainsToGenesis(`${chain}.json`, config.parachains);

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -115,9 +115,9 @@ export async function addGenesisParachain(
 	}
 }
 
-// Update the `parachainsConfiguration` in the genesis.
+// Update the `runtime_genesis_config` in the genesis.
 // It will try to match keys which exist within the configuration and update the value.
-export async function changeGenesisParachainsConfiguration(
+export async function changeGenesisConfig(
 	spec: string,
 	updates: any
 ) {
@@ -127,26 +127,35 @@ export async function changeGenesisParachainsConfiguration(
 	console.log(`\n⚙ Updating Parachains Genesis Configuration`);
 
 	if (
-		chainSpec.genesis.runtime.runtime_genesis_config &&
-		chainSpec.genesis.runtime.runtime_genesis_config.parachainsConfiguration
+		chainSpec.genesis.runtime.runtime_genesis_config
 	) {
-		let config =
-			chainSpec.genesis.runtime.runtime_genesis_config.parachainsConfiguration
-				.config;
-		Object.keys(updates).forEach((key) => {
-			if (config.hasOwnProperty(key)) {
-				config[key] = updates[key];
-				console.log(
-					`  ✓ Updated Parachains Configuration [ ${key}: ${config[key]} ]`
-				);
-			} else {
-				console.error(
-					`  ⚠ Bad Parachains Configuration [ ${key}: ${updates[key]} ]`
-				);
-			}
-		});
+		let config = chainSpec.genesis.runtime.runtime_genesis_config;
+		findAndReplaceConfig(updates, config);
 
 		let data = JSON.stringify(chainSpec, null, 2);
 		fs.writeFileSync(spec, data);
 	}
+}
+
+// Look at the key + values from `obj1` and try to replace them in `obj2`.
+function findAndReplaceConfig(obj1: any, obj2: any) {
+	// Look at keys of obj1
+	Object.keys(obj1).forEach(key => {
+		// See if obj2 also has this key
+		if (obj2.hasOwnProperty(key)) {
+			// If it goes deeper, recurse...
+			if (obj1[key].constructor === Object) {
+					findAndReplaceConfig(obj1[key], obj2[key])
+			} else {
+				obj2[key] = obj1[key];
+				console.log(
+					`  ✓ Updated Parachains Configuration [ ${key}: ${obj2[key]} ]`
+				);
+			}
+		} else {
+			console.error(
+				`  ⚠ Bad Parachains Configuration [ ${key}: ${obj1[key]} ]`
+			);
+		}
+	})
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -40,7 +40,7 @@ export interface RelayChainConfig {
 		port: number;
 		flags?: string[];
 	}[];
-	config?: JSON;
+	runtime_genesis_config?: JSON;
 }
 
 export interface ChainSpec {


### PR DESCRIPTION
Allows you to update the genesis configuration for any keys and values within `runtime_genesis_config`, leaving all other values the same.

```
		"runtime_genesis_config": {
			"parachainsConfiguration": {
				"config": {
					"validation_upgrade_frequency": 1,
					"validation_upgrade_delay": 1
				}
			},
			"palletCollective": {
				"members": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6"]
			}
		}
```