### PR TITLE
Allow to skip --parachain-id

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -60,6 +60,38 @@ export async function generateChainSpecRaw(bin: string, chain: string) {
 	});
 }
 
+export async function getParachainIdFromSpec(
+	bin: string,
+	chain?: string
+): Promise<number> {
+	const data = await new Promise<string>(function (resolve, reject) {
+		let args = ["build-spec"];
+		if (chain) {
+			args.push("--chain=" + chain);
+		}
+
+		let data = "";
+
+		p["spec"] = spawn(bin, args);
+		p["spec"].stdout.on("data", (chunk) => {
+			data += chunk;
+		});
+
+		p["spec"].stderr.pipe(process.stderr);
+
+		p["spec"].on("close", () => {
+			resolve(data);
+		});
+
+		p["spec"].on("error", (err) => {
+			reject(err);
+		});
+	});
+
+	const spec = JSON.parse(data);
+	return spec.para_id;
+}
+
 // Spawn a new relay chain node.
 // `name` must be `alice`, `bob`, `charlie`, etc... (hardcoded in Substrate).
 export function startNode(
@@ -147,7 +179,8 @@ export function startCollator(
 	name?: string,
 	chain?: string,
 	spec?: string,
-	flags?: string[]
+	flags?: string[],
+	skip_id_arg?: boolean
 ) {
 	return new Promise<void>(function (resolve) {
 		// TODO: Make DB directory configurable rather than just `tmp`
@@ -155,7 +188,6 @@ export function startCollator(
 			"--tmp",
 			"--ws-port=" + wsPort,
 			"--port=" + port,
-			"--parachain-id=" + id,
 			"--collator",
 			"--force-authoring",
 		];
@@ -164,7 +196,10 @@ export function startCollator(
 			args.push(`--${name.toLowerCase()}`);
 			console.log(`Added --${name.toLowerCase()}`);
 		}
-
+		if (!skip_id_arg) {
+			args.push("--parachain-id=" + id);
+			console.log(`Added --parachain-id=${id}`);
+		}
 		if (chain) {
 			args.push("--chain=" + chain);
 			console.log(`Added --chain=${chain}`);
@@ -215,16 +250,21 @@ export function startSimpleCollator(
 	bin: string,
 	id: string,
 	spec: string,
-	port: string
+	port: string,
+	skip_id_arg?: boolean
 ) {
 	return new Promise<void>(function (resolve) {
 		let args = [
 			"--tmp",
-			"--parachain-id=" + id,
 			"--port=" + port,
 			"--chain=" + spec,
 			"--execution=wasm",
 		];
+
+		if (!skip_id_arg) {
+			args.push("--parachain-id=" + id);
+			console.log(`Added --parachain-id=${id}`);
+		}
 
 		p[port] = spawn(bin, args);
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -15,14 +15,14 @@ export interface ParachainNodeConfig {
 }
 export interface ParachainConfig {
 	bin: string;
-	id: string;
+	id?: string;
 	balance: string;
 	chain?: string;
 	nodes: ParachainNodeConfig[];
 }
 export interface SimpleParachainConfig {
 	bin: string;
-	id: string;
+	id?: string;
 	port: string;
 	balance: string;
 }
@@ -64,4 +64,15 @@ export interface ChainSpec {
 			};
 		};
 	};
+}
+
+export interface ResolvedParachainConfig extends ParachainConfig {
+	resolvedId: string;
+}
+export interface ResolvedSimpleParachainConfig extends SimpleParachainConfig {
+	resolvedId: string;
+}
+export interface ResolvedLaunchConfig extends LaunchConfig {
+	parachains: ResolvedParachainConfig[];
+	simpleParachains: ResolvedSimpleParachainConfig[];
 }


### PR DESCRIPTION
In some situation, we already have the parachain id embedded in the chain spec file, and thus `--parachain-id` is not used (and maybe is even not supported in some node implementation).

This PR introduces "skip_id_arg" option in ParachainConfig to deal with that.