### PR TITLE
Adds name as parameter for collator nodes

### DIFF
--- a/config.json
+++ b/config.json
@@ -42,6 +42,7 @@
 				{
 					"wsPort": 9988,
 					"port": 31200,
+					"name": "alice",
 					"flags": ["--", "--execution=wasm"]
 				}
 			]
@@ -54,6 +55,7 @@
 				{
 					"wsPort": 9999,
 					"port": 31300,
+					"name": "alice",
 					"flags": ["--", "--execution=wasm"]
 				}
 			]
@@ -64,6 +66,7 @@
 			"bin": "./bin/adder-collator",
 			"id": "400",
 			"port": "31400",
+			"name": "alice",
 			"balance": "1000000000000000000000"
 		}
 	],

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,11 +122,11 @@ async function main() {
 		let account = parachainAccount(id);
 
 		for (const node of parachain.nodes) {
-			const { wsPort, port, flags } = node;
+			const { wsPort, port, flags, name } = node;
 			console.log(
 				`Starting a Collator for parachain ${id}: ${account}, Collator port : ${port} wsPort : ${wsPort}`
 			);
-			await startCollator(bin, id, wsPort, port, chain, spec, flags);
+			await startCollator(bin, id, wsPort, port, name, chain, spec, flags);
 		}
 
 		// Allow time for the TX to complete, avoiding nonce issues.

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -144,6 +144,7 @@ export function startCollator(
 	id: string,
 	wsPort: number,
 	port: number,
+	name?: string,
 	chain?: string,
 	spec?: string,
 	flags?: string[]
@@ -156,9 +157,13 @@ export function startCollator(
 			"--port=" + port,
 			"--parachain-id=" + id,
 			"--collator",
-			"--alice",
 			"--force-authoring"
 		];
+
+		if (name) {
+			args.push(`--${name.toLowerCase()}`);
+			console.log(`Added --${name.toLowerCase()}`);
+		}
 
 		if (chain) {
 			args.push("--chain=" + chain);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,7 @@ export interface ParachainNodeConfig {
 	rpcPort: number;
 	wsPort: number;
 	port: number;
+	name?: string;
 	flags: string[];
 }
 export interface ParachainConfig {


### PR DESCRIPTION
Collator currently has a --alice hardcoded parameter. That breaks for node requiring multiple different authors.
The proposal uses an optional "name" parameter like for validators