### PR TITLE
Prevent spec genesis replacement to fail for null value

### DIFF
--- a/src/spec.ts
+++ b/src/spec.ts
@@ -171,7 +171,11 @@ function findAndReplaceConfig(obj1: any, obj2: any) {
 		// See if obj2 also has this key
 		if (obj2.hasOwnProperty(key)) {
 			// If it goes deeper, recurse...
-			if (obj1[key].constructor === Object) {
+			if (
+				obj1[key] !== null &&
+				obj1[key] !== undefined &&
+				obj1[key].constructor === Object
+			) {
 				findAndReplaceConfig(obj1[key], obj2[key]);
 			} else {
 				obj2[key] = obj1[key];


### PR DESCRIPTION
If obj1[key] is null, accessing the constructor would fail
(This happens for object like phantom in genesis)

exemple of failure:
```
genesis: {
      runtime: {
        parachainsConfiguration: {
          config: {
            validation_upgrade_frequency: 1,
            validation_upgrade_delay: 1,
          },
        },
        palletCollectiveInstance1: {
          phantom: null,
          members: ["F5YRpySp2eGgVi1MdhEyk9GvUwFPQUbckhZNXeZ76SoPrtE"],
        },
      },
    },
```

For information, .constructor is not allowed null:
```
Uncaught TypeError: Cannot read property 'constructor' of null
```