### PR TITLE
Runtime Config fixes

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -3,6 +3,7 @@
 import { LaunchConfig } from "./types";
 export function checkConfig(config: LaunchConfig) {
 	if (!config) {
+		console.error("⚠ Missing config");
 		return false;
 	}
 

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -17,6 +17,14 @@ function getAuthorityKeys(chainSpec: ChainSpec) {
 	if (runtimeConfig && runtimeConfig.session) {
 		return runtimeConfig.session.keys;
 	}
+
+	// For retro-compatibility with substrate pre Polkadot 0.9.5
+	if (runtimeConfig && runtimeConfig.palletSession) {
+		return runtimeConfig.palletSession.keys;
+	}
+
+	console.error("  ⚠ session not found in runtimeConfig");
+	process.exit(1);
 }
 
 // Remove all existing keys from `session.keys`
@@ -26,7 +34,7 @@ export function clearAuthorities(spec: string) {
 	try {
 		chainSpec = JSON.parse(rawdata);
 	} catch {
-		console.error("failed to parse the chain spec");
+		console.error("  ⚠ failed to parse the chain spec");
 		process.exit(1);
 	}
 
@@ -93,9 +101,15 @@ export async function addGenesisParachain(
 	const runtimeConfig =
 		chainSpec.genesis.runtime.runtime_genesis_config ||
 		chainSpec.genesis.runtime;
-	if (runtimeConfig.parachainsParas) {
-		let paras = runtimeConfig.parachainsParas.paras;
-
+	let paras = undefined;
+	if (runtimeConfig.paras) {
+		paras = runtimeConfig.paras.paras;
+	}
+	// For retro-compatibility with substrate pre Polkadot 0.9.5
+	else if (runtimeConfig.parachainsParas) {
+		paras = runtimeConfig.parachainsParas.paras;
+	}
+	if (paras) {
 		let new_para = [
 			parseInt(para_id),
 			{
@@ -110,6 +124,9 @@ export async function addGenesisParachain(
 		let data = JSON.stringify(chainSpec, null, 2);
 		fs.writeFileSync(spec, data);
 		console.log(`  ✓ Added Genesis Parachain ${para_id}`);
+	} else {
+		console.error("  ⚠ paras not found in runtimeConfig");
+		process.exit(1);
 	}
 }
 
@@ -132,18 +149,30 @@ export async function addGenesisHrmpChannel(
 	const runtimeConfig =
 		chainSpec.genesis.runtime.runtime_genesis_config ||
 		chainSpec.genesis.runtime;
+	
+	let hrmp = undefined;
+
+	if (runtimeConfig.hrmp) {
+		hrmp = runtimeConfig.hrmp;
+	}
+	// For retro-compatibility with substrate pre Polkadot 0.9.5
+	else if (runtimeConfig.parachainsHrmp) {
+		hrmp = runtimeConfig.parachainsHrmp;
+	}
 
 	if (
-		runtimeConfig.parachainsHrmp &&
-		runtimeConfig.parachainsHrmp.preopenHrmpChannels
+		hrmp && hrmp.preopenHrmpChannels
 	) {
-		runtimeConfig.parachainsHrmp.preopenHrmpChannels.push(newHrmpChannel);
+		hrmp.preopenHrmpChannels.push(newHrmpChannel);
 
 		let data = JSON.stringify(chainSpec, null, 2);
 		fs.writeFileSync(spec, data);
 		console.log(
 			`  ✓ Added HRMP channel ${hrmpChannel.sender} -> ${hrmpChannel.recipient}`
 		);
+	} else {
+		console.error("  ⚠ hrmp not found in runtimeConfig");
+		process.exit(1);
 	}
 }
 


### PR DESCRIPTION
This PR fixes the `runtimeConfig` accesses in `spec.ts` to work with recent Polkadot/Substrate (genesis config format has changed [here](https://github.com/paritytech/substrate/pull/8990)).
It also adds error messages and early exits if they cannot be found.