### PR TITLE
Add yarn to shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -5,5 +5,6 @@ in
 pkgs.mkShell {
   buildInputs = [
     polkadot-launch
+    (yarn.override { nodejs = nodejs-14_x; })
   ];
 }


### PR DESCRIPTION
The nodejs override is required, because by default yarn comes with an
older version of node. Nowadays polkadot-js API requires node 14