### PR TITLE
fix: .json extension wrongly passed to chain name

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -40,7 +40,7 @@ export async function generateChainSpec(bin: string, chain: string) {
 export async function generateChainSpecRaw(bin: string, chain: string) {
 	console.log(); // Add a newline in output
 	return new Promise<void>(function (resolve, reject) {
-		let args = ["build-spec", "--chain=" + chain + ".json", "--raw"];
+		let args = ["build-spec", "--chain=" + chain, "--raw"];
 
 		p["spec"] = spawn(bin, args);
 		let spec = fs.createWriteStream(`${chain}-raw.json`);


### PR DESCRIPTION
Getting error on relay (polkadot v0.9.7) launch without this patch:

```
Error: 
   0: Invalid input: `rococo-local.json` only supported with `rococo-native` feature enabled.
```

Fixes #115