### PR TITLE
change key to new genesis format

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ An example of `genesis` is:
 "genesis": {
   "runtime": {
     "runtime_genesis_config": {
-      "parachainsConfiguration": {
+      "configuration": {
         "config": {
           "validation_upgrade_frequency": 1,
           "validation_upgrade_delay": 1
@@ -197,7 +197,7 @@ in order to create a local test network.
   node:
   - We build a fresh chain spec using the `chain` parameter specified in your config.
     - Includes the authorities you specified.
-    - Includes changes to the `parachainsConfiguration`.
+    - Includes changes to the `paras`.
     - Includes parachains you have added.
       - `wasm` is generated using the `<node> export-genesis-wasm` subcommand.
       - `header` is retrieved by calling `api.rpc.chain.getHeader(genesis_hash)`.

--- a/config.json
+++ b/config.json
@@ -27,7 +27,7 @@
 		"genesis": {
 			"runtime": {
 				"runtime_genesis_config": {
-					"parachainsConfiguration": {
+					"configuration": {
 						"config": {
 							"validation_upgrade_frequency": 1,
 							"validation_upgrade_delay": 1


### PR DESCRIPTION
The genesis format for Polkadot has changed, so the field `parachainsConfiguration` was renamed to `configuration`.