### PR TITLE
Don't force authoring on parachain nodes

### DIFF
--- a/config.json
+++ b/config.json
@@ -47,7 +47,7 @@
 					"wsPort": 9988,
 					"port": 31200,
 					"name": "alice",
-					"flags": ["--", "--execution=wasm"]
+					"flags": ["--force-authoring", "--", "--execution=wasm"]
 				}
 			]
 		},
@@ -60,7 +60,7 @@
 					"wsPort": 9999,
 					"port": 31300,
 					"name": "alice",
-					"flags": ["--", "--execution=wasm"]
+					"flags": ["--force-authoring", "--", "--execution=wasm"]
 				}
 			]
 		}

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -195,7 +195,6 @@ export function startCollator(
 			"--ws-port=" + wsPort,
 			"--port=" + port,
 			"--collator",
-			"--force-authoring",
 		];
 
 		if (basePath) {


### PR DESCRIPTION
Before this PR, polkadot launch will add the `--force-authoring` flag to every collator node, and there is no way to tell it otherwise in the config file.

This PR removes that flag from the mandatory list of flags. It is still possible for anyone who actually wants to force authoring to add that flag in their config.

If the maintainers think that forcing authoring is a sensible default, I could add it to the provided example config.