### PR TITLE
Update yarn.nix to fix nix-shell

### DIFF
--- a/yarn.nix
+++ b/yarn.nix
@@ -2,14 +2,6 @@
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
-      name = "_babel_runtime___runtime_7.14.0.tgz";
-      path = fetchurl {
-        name = "_babel_runtime___runtime_7.14.0.tgz";
-        url  = "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.0.tgz";
-        sha1 = "46794bc20b612c5f75e62dd071e24dfd95f1cbe6";
-      };
-    }
-    {
       name = "_babel_runtime___runtime_7.14.6.tgz";
       path = fetchurl {
         name = "_babel_runtime___runtime_7.14.6.tgz";
@@ -18,171 +10,163 @@
       };
     }
     {
-      name = "_polkadot_api_derive___api_derive_4.17.1.tgz";
+      name = "_babel_runtime___runtime_7.14.8.tgz";
       path = fetchurl {
-        name = "_polkadot_api_derive___api_derive_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-4.17.1.tgz";
-        sha1 = "7902ab73159f89a4f1a896ce856dd7377318d275";
+        name = "_babel_runtime___runtime_7.14.8.tgz";
+        url  = "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz";
+        sha1 = "7119a56f421018852694290b9f9148097391b446";
       };
     }
     {
-      name = "_polkadot_api___api_4.17.1.tgz";
+      name = "_polkadot_api_derive___api_derive_5.3.2.tgz";
       path = fetchurl {
-        name = "_polkadot_api___api_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/api/-/api-4.17.1.tgz";
-        sha1 = "c9c8e7f5e33122aeb5b1345e43bc9579658720db";
+        name = "_polkadot_api_derive___api_derive_5.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/api-derive/-/api-derive-5.3.2.tgz";
+        sha1 = "ac4f5a0dd1a481ff4f42b58ba9fc7a89a82561bf";
       };
     }
     {
-      name = "_polkadot_keyring___keyring_6.11.1.tgz";
+      name = "_polkadot_api___api_5.3.2.tgz";
       path = fetchurl {
-        name = "_polkadot_keyring___keyring_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-6.11.1.tgz";
-        sha1 = "2510c349c965c74cc2f108f114f1048856940604";
+        name = "_polkadot_api___api_5.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/api/-/api-5.3.2.tgz";
+        sha1 = "b5f5ba949d2aec9789c5acd0b72f106d6241d60d";
       };
     }
     {
-      name = "_polkadot_metadata___metadata_4.17.1.tgz";
+      name = "_polkadot_keyring___keyring_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_metadata___metadata_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/metadata/-/metadata-4.17.1.tgz";
-        sha1 = "4da9ee5b2b816493910abfd302a50b58141ceca2";
+        name = "_polkadot_keyring___keyring_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/keyring/-/keyring-7.1.1.tgz";
+        sha1 = "5790cfd20bb25bc4dd09e54d15e12ee69c73ceef";
       };
     }
     {
-      name = "_polkadot_networks___networks_6.11.1.tgz";
+      name = "_polkadot_networks___networks_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_networks___networks_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/networks/-/networks-6.11.1.tgz";
-        sha1 = "8fd189593f6ee4f8bf64378d0aaae09e39a37d35";
+        name = "_polkadot_networks___networks_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/networks/-/networks-7.1.1.tgz";
+        sha1 = "ef1e190961dffa5e9f33ec7a5929f1d82bdb3761";
       };
     }
     {
-      name = "_polkadot_rpc_core___rpc_core_4.17.1.tgz";
+      name = "_polkadot_rpc_core___rpc_core_5.3.2.tgz";
       path = fetchurl {
-        name = "_polkadot_rpc_core___rpc_core_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-4.17.1.tgz";
-        sha1 = "b9fa739fa98e4355fdc2b8d2b43b3a4b9d32dac4";
+        name = "_polkadot_rpc_core___rpc_core_5.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/rpc-core/-/rpc-core-5.3.2.tgz";
+        sha1 = "e9dc5b2c38f5f81dcdf9714c4de36817df31b458";
       };
     }
     {
-      name = "_polkadot_rpc_provider___rpc_provider_4.17.1.tgz";
+      name = "_polkadot_rpc_provider___rpc_provider_5.3.2.tgz";
       path = fetchurl {
-        name = "_polkadot_rpc_provider___rpc_provider_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-4.17.1.tgz";
-        sha1 = "1f99b8365d0f76f714f613423e6a1832b5d833b3";
+        name = "_polkadot_rpc_provider___rpc_provider_5.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/rpc-provider/-/rpc-provider-5.3.2.tgz";
+        sha1 = "ef5f0b6357759aadc96356943ecbed60e66b701e";
       };
     }
     {
-      name = "_polkadot_types_known___types_known_4.17.1.tgz";
+      name = "_polkadot_types_known___types_known_5.3.2.tgz";
       path = fetchurl {
-        name = "_polkadot_types_known___types_known_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-4.17.1.tgz";
-        sha1 = "71c18dda4967a13ec34fbbf0c4ef264e882c2688";
+        name = "_polkadot_types_known___types_known_5.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/types-known/-/types-known-5.3.2.tgz";
+        sha1 = "7a1bb5abefb85d056ba8de2772d41f2ecd3b420c";
       };
     }
     {
-      name = "_polkadot_types___types_4.17.1.tgz";
+      name = "_polkadot_types___types_5.3.2.tgz";
       path = fetchurl {
-        name = "_polkadot_types___types_4.17.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/types/-/types-4.17.1.tgz";
-        sha1 = "41d43621d53820ee930ba4036bfa8b16cf98ca6f";
+        name = "_polkadot_types___types_5.3.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/types/-/types-5.3.2.tgz";
+        sha1 = "6b5849172c1280bab24865a6e09c75a941690b6d";
       };
     }
     {
-      name = "_polkadot_util_crypto___util_crypto_6.11.1.tgz";
+      name = "_polkadot_util_crypto___util_crypto_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_util_crypto___util_crypto_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-6.11.1.tgz";
-        sha1 = "7a36acf5c8bf52541609ec0b0b2a69af295d652e";
+        name = "_polkadot_util_crypto___util_crypto_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/util-crypto/-/util-crypto-7.1.1.tgz";
+        sha1 = "48895489686ef922afadc49c08f5d9678e3120a1";
       };
     }
     {
-      name = "_polkadot_util___util_6.11.1.tgz";
+      name = "_polkadot_util___util_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_util___util_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/util/-/util-6.11.1.tgz";
-        sha1 = "8950b038ba3e6ebfc0a7ff47feeb972e81b2626c";
+        name = "_polkadot_util___util_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/util/-/util-7.1.1.tgz";
+        sha1 = "1df133296ecd194a566677b68e51f93118f11c1e";
       };
     }
     {
-      name = "_polkadot_wasm_crypto_asmjs___wasm_crypto_asmjs_4.0.2.tgz";
+      name = "_polkadot_wasm_crypto_asmjs___wasm_crypto_asmjs_4.1.2.tgz";
       path = fetchurl {
-        name = "_polkadot_wasm_crypto_asmjs___wasm_crypto_asmjs_4.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.0.2.tgz";
-        sha1 = "f42c353a64e1243841daf90e4bd54eff01a4e3cf";
+        name = "_polkadot_wasm_crypto_asmjs___wasm_crypto_asmjs_4.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/wasm-crypto-asmjs/-/wasm-crypto-asmjs-4.1.2.tgz";
+        sha1 = "094b3eeeb5fd39a93db177583b48454511874cfc";
       };
     }
     {
-      name = "_polkadot_wasm_crypto_wasm___wasm_crypto_wasm_4.0.2.tgz";
+      name = "_polkadot_wasm_crypto_wasm___wasm_crypto_wasm_4.1.2.tgz";
       path = fetchurl {
-        name = "_polkadot_wasm_crypto_wasm___wasm_crypto_wasm_4.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.0.2.tgz";
-        sha1 = "89f9e0a1e4d076784d4a42bea37fc8b06bdd8bb6";
+        name = "_polkadot_wasm_crypto_wasm___wasm_crypto_wasm_4.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/wasm-crypto-wasm/-/wasm-crypto-wasm-4.1.2.tgz";
+        sha1 = "773c78c1d65886671d3ba1d66c31afd86c93d02f";
       };
     }
     {
-      name = "_polkadot_wasm_crypto___wasm_crypto_4.0.2.tgz";
+      name = "_polkadot_wasm_crypto___wasm_crypto_4.1.2.tgz";
       path = fetchurl {
-        name = "_polkadot_wasm_crypto___wasm_crypto_4.0.2.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.0.2.tgz";
-        sha1 = "9649057adee8383cc86433d107ba526b718c5a3b";
+        name = "_polkadot_wasm_crypto___wasm_crypto_4.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/wasm-crypto/-/wasm-crypto-4.1.2.tgz";
+        sha1 = "dead71ae5d2f7722d23aed5be2112e1732d315e9";
       };
     }
     {
-      name = "_polkadot_x_fetch___x_fetch_6.11.1.tgz";
+      name = "_polkadot_x_fetch___x_fetch_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_x_fetch___x_fetch_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-6.11.1.tgz";
-        sha1 = "97d44d78ef0285eec6f6dbc4006302308ec8e24c";
+        name = "_polkadot_x_fetch___x_fetch_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/x-fetch/-/x-fetch-7.1.1.tgz";
+        sha1 = "ed40e00b0844c31eddf33ae6f8bf378a9c085a18";
       };
     }
     {
-      name = "_polkadot_x_global___x_global_6.11.1.tgz";
+      name = "_polkadot_x_global___x_global_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_x_global___x_global_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-6.11.1.tgz";
-        sha1 = "c292b3825fea60e9b33fff1790323fc57de1ca5d";
+        name = "_polkadot_x_global___x_global_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/x-global/-/x-global-7.1.1.tgz";
+        sha1 = "ca7ebec3b336120af999fc55a8939be4a910274f";
       };
     }
     {
-      name = "_polkadot_x_randomvalues___x_randomvalues_6.11.1.tgz";
+      name = "_polkadot_x_randomvalues___x_randomvalues_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_x_randomvalues___x_randomvalues_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-6.11.1.tgz";
-        sha1 = "f006fa250c8e82c92ccb769976a45a8e7f3df28b";
+        name = "_polkadot_x_randomvalues___x_randomvalues_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/x-randomvalues/-/x-randomvalues-7.1.1.tgz";
+        sha1 = "d4b293a396291609b34fcb35aa40207dd75c9b23";
       };
     }
     {
-      name = "_polkadot_x_rxjs___x_rxjs_6.11.1.tgz";
+      name = "_polkadot_x_textdecoder___x_textdecoder_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_x_rxjs___x_rxjs_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-rxjs/-/x-rxjs-6.11.1.tgz";
-        sha1 = "5454708b61da70eea05708611d9148fce9372498";
+        name = "_polkadot_x_textdecoder___x_textdecoder_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-7.1.1.tgz";
+        sha1 = "a7e0a0259f49bdb405d665355bbbc85f79e06790";
       };
     }
     {
-      name = "_polkadot_x_textdecoder___x_textdecoder_6.11.1.tgz";
+      name = "_polkadot_x_textencoder___x_textencoder_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_x_textdecoder___x_textdecoder_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-textdecoder/-/x-textdecoder-6.11.1.tgz";
-        sha1 = "6cc314645681cc4639085c03b65328671c7f182c";
+        name = "_polkadot_x_textencoder___x_textencoder_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-7.1.1.tgz";
+        sha1 = "700938abed80a2c1ff277dcd7b696aca22ec7b50";
       };
     }
     {
-      name = "_polkadot_x_textencoder___x_textencoder_6.11.1.tgz";
+      name = "_polkadot_x_ws___x_ws_7.1.1.tgz";
       path = fetchurl {
-        name = "_polkadot_x_textencoder___x_textencoder_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-textencoder/-/x-textencoder-6.11.1.tgz";
-        sha1 = "73e89da5b91954ae380042c19314c90472f59d9e";
-      };
-    }
-    {
-      name = "_polkadot_x_ws___x_ws_6.11.1.tgz";
-      path = fetchurl {
-        name = "_polkadot_x_ws___x_ws_6.11.1.tgz";
-        url  = "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-6.11.1.tgz";
-        sha1 = "338adc7309e3a8e660fce8eb42f975426da48d10";
+        name = "_polkadot_x_ws___x_ws_7.1.1.tgz";
+        url  = "https://registry.yarnpkg.com/@polkadot/x-ws/-/x-ws-7.1.1.tgz";
+        sha1 = "6401017f8824b0c021a2c6cdb7f3de0e581d54a2";
       };
     }
     {
@@ -194,11 +178,11 @@
       };
     }
     {
-      name = "_types_node_fetch___node_fetch_2.5.10.tgz";
+      name = "_types_node_fetch___node_fetch_2.5.12.tgz";
       path = fetchurl {
-        name = "_types_node_fetch___node_fetch_2.5.10.tgz";
-        url  = "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.10.tgz";
-        sha1 = "9b4d4a0425562f9fcea70b12cb3fcdd946ca8132";
+        name = "_types_node_fetch___node_fetch_2.5.12.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.5.12.tgz";
+        sha1 = "8a6f779b1d4e60b7a57fb6fd48d84fb545b9cc66";
       };
     }
     {
@@ -210,11 +194,19 @@
       };
     }
     {
-      name = "_types_websocket___websocket_1.0.3.tgz";
+      name = "_types_node___node_16.4.12.tgz";
       path = fetchurl {
-        name = "_types_websocket___websocket_1.0.3.tgz";
-        url  = "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.3.tgz";
-        sha1 = "49e09f939afd0ccdee4f7108d4712ec9feb0f153";
+        name = "_types_node___node_16.4.12.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.4.12.tgz";
+        sha1 = "961e3091f263e6345d2d84afab4e047a60b4b11b";
+      };
+    }
+    {
+      name = "_types_websocket___websocket_1.0.4.tgz";
+      path = fetchurl {
+        name = "_types_websocket___websocket_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/@types/websocket/-/websocket-1.0.4.tgz";
+        sha1 = "1dc497280d8049a5450854dd698ee7e6ea9e60b8";
       };
     }
     {
@@ -383,6 +375,14 @@
         name = "delayed_stream___delayed_stream_1.0.0.tgz";
         url  = "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz";
         sha1 = "df3ae199acadfb7d440aaae0b29e2272b24ec619";
+      };
+    }
+    {
+      name = "ed2curve___ed2curve_0.3.0.tgz";
+      path = fetchurl {
+        name = "ed2curve___ed2curve_0.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/ed2curve/-/ed2curve-0.3.0.tgz";
+        sha1 = "322b575152a45305429d546b071823a93129a05d";
       };
     }
     {
@@ -698,11 +698,11 @@
       };
     }
     {
-      name = "rxjs___rxjs_6.6.7.tgz";
+      name = "rxjs___rxjs_7.3.0.tgz";
       path = fetchurl {
-        name = "rxjs___rxjs_6.6.7.tgz";
-        url  = "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz";
-        sha1 = "90ac018acabf491bf65044235d5863c4dab804c9";
+        name = "rxjs___rxjs_7.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/rxjs/-/rxjs-7.3.0.tgz";
+        sha1 = "39fe4f3461dc1e50be1475b2b85a0a88c1e938c6";
       };
     }
     {
@@ -762,11 +762,11 @@
       };
     }
     {
-      name = "tslib___tslib_1.14.1.tgz";
+      name = "tslib___tslib_2.1.0.tgz";
       path = fetchurl {
-        name = "tslib___tslib_1.14.1.tgz";
-        url  = "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz";
-        sha1 = "cf2d38bdc34a134bcaf1091c41f6619e2f672d00";
+        name = "tslib___tslib_2.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz";
+        sha1 = "da60860f1c2ecaa5703ab7d39bc05b6bf988b97a";
       };
     }
     {
@@ -802,11 +802,11 @@
       };
     }
     {
-      name = "typescript___typescript_4.1.5.tgz";
+      name = "typescript___typescript_4.3.5.tgz";
       path = fetchurl {
-        name = "typescript___typescript_4.1.5.tgz";
-        url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz";
-        sha1 = "123a3b214aaff3be32926f0d8f1f6e704eb89a72";
+        name = "typescript___typescript_4.3.5.tgz";
+        url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz";
+        sha1 = "4d1c37cc16e893973c45a06886b7113234f119f4";
       };
     }
     {


### PR DESCRIPTION
With current `yarn.nix`, I will get following error when I run `nix-shell`

```
→ nix-shell
warning: dumping very large path (> 256 MiB); this may run out of memory
these derivations will be built:
  /nix/store/5klvfkq6lfjjyp431m11d3z78zhscgx8-polkadot-launch-modules-1.7.0.drv
  /nix/store/k8r5phivk7076ixfrycizf6kfrclvpyj-polkadot-launch.drv
building '/nix/store/5klvfkq6lfjjyp431m11d3z78zhscgx8-polkadot-launch-modules-1.7.0.drv'...
patching sources
configuring
building
yarn config v1.22.11
success Set "yarn-offline-mirror" to "/nix/store/9cxkzkgjw1q61c5kczjzv16cqgkn29z3-offline".
✨  Done in 0.06s.
yarn install v1.22.11
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[] 0/114error Can't make a request in offline mode ("https://registry.yarnpkg.com/typescript___typescript_4.3.5.tgz")
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

builder for '/nix/store/5klvfkq6lfjjyp431m11d3z78zhscgx8-polkadot-launch-modules-1.7.0.drv' failed with exit code 1
cannot build derivation '/nix/store/k8r5phivk7076ixfrycizf6kfrclvpyj-polkadot-launch.drv': 1 dependencies couldn't be built
error: build of '/nix/store/k8r5phivk7076ixfrycizf6kfrclvpyj-polkadot-launch.drv' failed
```

so, I just tried to regenerate the yarn.nix and I can get into the nix-shell successfully now.

---

My nix environment

```sh
→ nix-env --version
nix-env (Nix) 2.3.15

→ nix-shell --version
nix-shell (Nix) 2.3.15

→ nix-channel --list
nixpkgs https://nixos.org/channels/nixpkgs-unstable
```

