### PR TITLE
Move TS to devDependencies and remove unused package `yarn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 		"@polkadot/util": "^7.1.1",
 		"@polkadot/util-crypto": "^7.1.1",
 		"filter-console": "^0.1.1",
-		"typescript": "^4.1.5",
 		"yargs": "^15.4.1",
 		"yarn": "^1.22.10"
 	},
@@ -28,6 +27,7 @@
 	},
 	"devDependencies": {
 		"@types/node": "^16.4.12",
-		"prettier": "2.2.1"
+		"prettier": "2.2.1",
+		"typescript": "^4.1.5"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,7 @@
 		"@polkadot/util": "^7.1.1",
 		"@polkadot/util-crypto": "^7.1.1",
 		"filter-console": "^0.1.1",
-		"yargs": "^15.4.1",
-		"yarn": "^1.22.10"
+		"yargs": "^15.4.1"
 	},
 	"files": [
 		"dist"

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,8 +806,3 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
-
-yarn@^1.22.10:
-  version "1.22.10"
-  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
-  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==

--- a/yarn.nix
+++ b/yarn.nix
@@ -889,13 +889,5 @@
         sha1 = "0d87a16de01aee9d8bec2bfbf74f67851730f4f8";
       };
     }
-    {
-      name = "yarn___yarn_1.22.10.tgz";
-      path = fetchurl {
-        name = "yarn___yarn_1.22.10.tgz";
-        url  = "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz";
-        sha1 = "c99daa06257c80f8fa2c3f1490724e394c26b18c";
-      };
-    }
   ];
 }


### PR DESCRIPTION
I just noticed that `typescript` lives in the `dependencies` but I think it's only for development purpose. So, with moving it to `devDependencies`, it should help the `polkadot-launch` users avoid installing it.

Also, I noticed there's `yarn` in the `dependencies` but it seems it's not used in the codebase. I wonder it might be okay to remove it from the dependencies?

(Not sure if I should increment the patch number in package.json for this PR?)