### PR TITLE
Do not include polkadot-launch in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,10 +1,6 @@
 { pkgs ? import <nixpkgs> { } }:
-let
-  polkadot-launch = pkgs.callPackage ./default.nix { };
-in
 with pkgs; mkShell {
   buildInputs = [
-    polkadot-launch
     (yarn.override { nodejs = nodejs-14_x; })
   ];
 }


### PR DESCRIPTION
The reason for this is that, shell.nix is used for setting up the
development environment, when you work are developing the project.

For that, IMO, it's way more convenient to use `yarn`. The reason for
that is that when you change something you can immediatelly run `yarn
start` and see the results.

However, in order to start the shell via lorri or whatever any changes
to this project will trigger nix rebuild which can take quite some time.

So I think it would be better in the end to remove polkadot-launch from
here. If needed, it can be installed from ./default.nix