### PR TITLE
Make sure validator nodes can find each other

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You can see an example [here](config.json).
   - `name`: Must be one of `alice`, `bob`, `charlie`, or `dave`.
   - `wsPort`: The websocket port for this node.
   - `port`: The TCP port for this node.
+  - `nodeKey`: a secret key used for generating libp2p peer identifier. Optional.
   - `basePath`: The directory used for the blockchain db and other outputs. When unspecified, we use
     `--tmp`.
   - `flags`: Any additional command line flags you want to add when starting your node.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 		"@polkadot/util": "^7.4.1",
 		"@polkadot/util-crypto": "^7.4.1",
 		"filter-console": "^0.1.1",
+		"libp2p-crypto": "^0.20.0",
+		"peer-id": "^0.15.3",
 		"yargs": "^15.4.1"
 	},
 	"files": [

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -22,7 +22,7 @@ import {
 } from "./spec";
 import { parachainAccount } from "./parachain";
 import { ApiPromise } from "@polkadot/api";
-import { randomAsHex } from '@polkadot/util-crypto';
+import { randomAsHex } from "@polkadot/util-crypto";
 
 import { resolve } from "path";
 import fs from "fs";
@@ -285,18 +285,25 @@ async function resolveParachainId(
 	return resolvedConfig;
 }
 
-async function generateNodeKeys(config: ResolvedLaunchConfig): Promise<string[]> {
-	var bootnodes = []
+async function generateNodeKeys(
+	config: ResolvedLaunchConfig
+): Promise<string[]> {
+	var bootnodes = [];
 	for (const node of config.relaychain.nodes) {
 		if (!node.nodeKey) {
 			node.nodeKey = hexStripPrefix(randomAsHex(32));
 		}
 
-		let pair = await libp2pKeys
-			.generateKeyPairFromSeed("Ed25519", hexToU8a(hexAddPrefix(node.nodeKey!)), 1024)
+		let pair = await libp2pKeys.generateKeyPairFromSeed(
+			"Ed25519",
+			hexToU8a(hexAddPrefix(node.nodeKey!)),
+			1024
+		);
 		let peerId: PeerId = await PeerId.createFromPrivKey(pair.bytes);
-		bootnodes.push(`/ip4/127.0.0.1/tcp/${node.port}/p2p/${peerId.toB58String()}`);
+		bootnodes.push(
+			`/ip4/127.0.0.1/tcp/${node.port}/p2p/${peerId.toB58String()}`
+		);
 	}
 
-	return bootnodes
+	return bootnodes;
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -18,9 +18,11 @@ import {
 	changeGenesisConfig,
 	addGenesisParachain,
 	addGenesisHrmpChannel,
+	addBootNodes,
 } from "./spec";
 import { parachainAccount } from "./parachain";
 import { ApiPromise } from "@polkadot/api";
+import { randomAsHex } from '@polkadot/util-crypto';
 
 import { resolve } from "path";
 import fs from "fs";
@@ -31,7 +33,9 @@ import type {
 	HrmpChannelsConfig,
 	ResolvedLaunchConfig,
 } from "./types";
-import { type } from "os";
+import { keys as libp2pKeys } from "libp2p-crypto";
+import { hexAddPrefix, hexStripPrefix, hexToU8a } from "@polkadot/util";
+import PeerId from "peer-id";
 
 function loadTypeDef(types: string | object): object {
 	if (typeof types === "string") {
@@ -59,6 +63,7 @@ export async function run(config_dir: string, rawConfig: LaunchConfig) {
 		return;
 	}
 	const config = await resolveParachainId(config_dir, rawConfig);
+	var bootnodes = await generateNodeKeys(config);
 
 	const relay_chain_bin = resolve(config_dir, config.relaychain.bin);
 	if (!fs.existsSync(relay_chain_bin)) {
@@ -84,15 +89,16 @@ export async function run(config_dir: string, rawConfig: LaunchConfig) {
 	if (config.hrmpChannels) {
 		await addHrmpChannelsToGenesis(`${chain}.json`, config.hrmpChannels);
 	}
+	addBootNodes(`${chain}.json`, bootnodes);
 	// -- End Chain Spec Modify --
 	await generateChainSpecRaw(relay_chain_bin, chain);
 	const spec = resolve(`${chain}-raw.json`);
 
 	// First we launch each of the validators for the relay chain.
 	for (const node of config.relaychain.nodes) {
-		const { name, wsPort, rpcPort, port, flags, basePath } = node;
+		const { name, wsPort, rpcPort, port, flags, basePath, nodeKey } = node;
 		console.log(
-			`Starting Relaychain Node ${name}... wsPort: ${wsPort} rpcPort: ${rpcPort} port: ${port}`
+			`Starting Relaychain Node ${name}... wsPort: ${wsPort} rpcPort: ${rpcPort} port: ${port} nodeKey: ${nodeKey}`
 		);
 		// We spawn a `child_process` starting a node, and then wait until we
 		// able to connect to it using PolkadotJS in order to know its running.
@@ -102,6 +108,7 @@ export async function run(config_dir: string, rawConfig: LaunchConfig) {
 			wsPort,
 			rpcPort,
 			port,
+			nodeKey!, // by the time the control flow gets here it should be assigned.
 			spec,
 			flags,
 			basePath
@@ -276,4 +283,20 @@ async function resolveParachainId(
 		parachain.resolvedId = parachain.id;
 	}
 	return resolvedConfig;
+}
+
+async function generateNodeKeys(config: ResolvedLaunchConfig): Promise<string[]> {
+	var bootnodes = []
+	for (const node of config.relaychain.nodes) {
+		if (!node.nodeKey) {
+			node.nodeKey = hexStripPrefix(randomAsHex(32));
+		}
+
+		let pair = await libp2pKeys
+			.generateKeyPairFromSeed("Ed25519", hexToU8a(hexAddPrefix(node.nodeKey!)), 1024)
+		let peerId: PeerId = await PeerId.createFromPrivKey(pair.bytes);
+		bootnodes.push(`/ip4/127.0.0.1/tcp/${node.port}/p2p/${peerId.toB58String()}`);
+	}
+
+	return bootnodes
 }

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -100,6 +100,7 @@ export function startNode(
 	wsPort: number,
 	rpcPort: number | undefined,
 	port: number,
+	nodeKey: string,
 	spec: string,
 	flags?: string[],
 	basePath?: string
@@ -109,6 +110,7 @@ export function startNode(
 		"--chain=" + spec,
 		"--ws-port=" + wsPort,
 		"--port=" + port,
+		"--node-key=" + nodeKey,
 		"--" + name.toLowerCase(),
 	];
 	if (rpcPort) {

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -215,3 +215,12 @@ function findAndReplaceConfig(obj1: any, obj2: any) {
 		}
 	});
 }
+
+export async function addBootNodes(spec: any, addresses: any) {
+	let rawdata = fs.readFileSync(spec);
+	let chainSpec = JSON.parse(rawdata);
+	chainSpec.bootNodes = addresses;
+	let data = JSON.stringify(chainSpec, null, 2);
+	fs.writeFileSync(spec, data);
+	console.log(`Added Boot Nodes: ${addresses}`);
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -41,6 +41,7 @@ export interface RelayChainConfig {
 		basePath?: string;
 		wsPort: number;
 		rpcPort?: number;
+		nodeKey?: string;
 		port: number;
 		flags?: string[];
 	}[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -210,12 +210,70 @@
     "@types/websocket" "^1.0.4"
     websocket "^1.0.34"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+
 "@types/bn.js@^4.11.6":
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
   integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
   dependencies:
     "@types/node" "*"
+
+"@types/long@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
+  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
 
 "@types/node-fetch@^2.5.12":
   version "2.5.12"
@@ -229,6 +287,11 @@
   version "16.10.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz#7a8f2838603ea314d1d22bb3171d899e15c57bd5"
   integrity sha512-ho3Ruq+fFnBrZhUYI46n/bV2GjwzSkwuT4dTf0GkuNFmnb8nq4ny2z9JEVemFi6bdEJanHLlYfy9c6FN9B9McQ==
+
+"@types/node@>=13.7.0":
+  version "16.11.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.8.tgz#a1aeb23f0aa33cb111e64ccaa1687b2ae0423b69"
+  integrity sha512-hmT5gfpRkkHr7DZZHMf3jBe/zNcVGN+jXSL2f8nAsYfBPxQFToKwQlS/zES4Sjp488Bi73i+p6bvrNRRGU0x9Q==
 
 "@types/websocket@^1.0.4":
   version "1.0.4"
@@ -249,6 +312,16 @@ ansi-styles@^4.0.0:
   dependencies:
     color-convert "^2.0.1"
 
+asn1.js@^5.0.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz#11a980b84ebb91781ce35b0fdc2ee294e3783f07"
+  integrity sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==
+  dependencies:
+    bn.js "^4.0.0"
+    inherits "^2.0.1"
+    minimalistic-assert "^1.0.0"
+    safer-buffer "^2.1.0"
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -266,12 +339,19 @@ base64-js@^1.5.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 blakejs@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.1.tgz#bf313053978b2cd4c444a48795710be05c785702"
   integrity sha512-bLG6PHOCZJKNshTjGRBvET0vTciwQE6zFKOKKXPDJfwFBd4Ac0yBfPZqcGvGJap50l7ktvlpFqc2jGVaUgbJgg==
 
-bn.js@^4.11.9, bn.js@^4.12.0:
+bn.js@^4.0.0, bn.js@^4.11.9, bn.js@^4.12.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -305,6 +385,11 @@ cipher-base@^1.0.1:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+class-is@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
+  integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
 
 cliui@^6.0.0:
   version "6.0.0"
@@ -382,7 +467,7 @@ ed2curve@^0.3.0:
   dependencies:
     tweetnacl "1.x.x"
 
-elliptic@^6.5.4:
+elliptic@^6.5.2, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -399,6 +484,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+err-code@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/err-code/-/err-code-3.0.1.tgz#a444c7b992705f2b120ee320b09972eef331c920"
+  integrity sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==
 
 es5-ext@^0.10.35, es5-ext@^0.10.50:
   version "0.10.53"
@@ -431,12 +521,22 @@ eventemitter3@^4.0.7:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
+events@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
+  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
 ext@^1.1.2:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz#3871d50641e874cc172e2b53f919842d19db4c52"
   integrity sha512-sdBImtzkq2HpkdRLtlLWDa6w4DX22ijZLKx8BMPUuKe1c5lbN6xwQDQCxSfxBQnHZ13ls/FH0MQZx/q/gr6FQg==
   dependencies:
     type "^2.5.0"
+
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
 
 filter-console@^0.1.1:
   version "0.1.1"
@@ -511,10 +611,57 @@ is-typedarray@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+iso-random-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-2.0.0.tgz#3f0118166d5443148bbc134345fb100002ad0f1d"
+  integrity sha512-lGuIu104KfBV9ubYTSaE3GeAr6I69iggXxBHbTBc5u/XKlwlWl0LCytnkIZissaKqvxablwRD9B3ktVnmIUnEg==
+  dependencies:
+    events "^3.3.0"
+    readable-stream "^3.4.0"
+
 js-sha3@^0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
   integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
+keypair@^1.0.1, keypair@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/keypair/-/keypair-1.0.4.tgz#a749a45f388593f3950f18b3757d32a93bd8ce83"
+  integrity sha512-zwhgOhhniaL7oxMgUMKKw5219PWWABMO+dgMnzJOQ2/5L3XJtTJGhW2PEXlxXj9zaccdReZJZ83+4NPhVfNVDg==
+
+libp2p-crypto@^0.19.0:
+  version "0.19.7"
+  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.19.7.tgz#e96a95bd430e672a695209fe0fbd2bcbd348bc35"
+  integrity sha512-Qb5o/3WFKF2j6mYSt4UBPyi2kbKl3jYV0podBJoJCw70DlpM5Xc+oh3fFY9ToSunu8aSQQ5GY8nutjXgX/uGRA==
+  dependencies:
+    err-code "^3.0.1"
+    is-typedarray "^1.0.0"
+    iso-random-stream "^2.0.0"
+    keypair "^1.0.1"
+    multiformats "^9.4.5"
+    node-forge "^0.10.0"
+    pem-jwk "^2.0.0"
+    protobufjs "^6.11.2"
+    secp256k1 "^4.0.0"
+    uint8arrays "^3.0.0"
+    ursa-optional "^0.10.1"
+
+libp2p-crypto@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.20.0.tgz#3881ccff5f1f51f48c74050d685535fb1a728488"
+  integrity sha512-WgIW9rYcWaO/5j2T6NW3R6Q46yvp2ZfFErqRMbi4/pOTL3T7+OROYpL/1iWVksWkXyurU/t2qFsIijWMxR5C4Q==
+  dependencies:
+    err-code "^3.0.1"
+    iso-random-stream "^2.0.0"
+    keypair "^1.0.4"
+    multiformats "^9.4.5"
+    noble-ed25519 "^1.2.6"
+    noble-secp256k1 "^1.2.10"
+    node-forge "^0.10.0"
+    pem-jwk "^2.0.0"
+    protobufjs "^6.11.2"
+    uint8arrays "^3.0.0"
+    ursa-optional "^0.10.1"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -522,6 +669,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 md5.js@^1.3.4:
   version "1.3.5"
@@ -554,15 +706,45 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
+multiformats@^9.4.2, multiformats@^9.4.5:
+  version "9.4.10"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.4.10.tgz#d654d06b28cc066506e4e59b246d65267fb6b93b"
+  integrity sha512-BwWGvgqB/5J/cnWaOA0sXzJ+UGl+kyFAw3Sw1L6TN4oad34C9OpW+GCpYTYPDp4pUaXDC1EjvB3yv9Iodo1EhA==
+
+nan@^2.14.2:
+  version "2.15.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz#3f34a473ff18e15c1b5626b62903b5ad6e665fee"
+  integrity sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==
+
 next-tick@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
   integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
+
+noble-ed25519@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/noble-ed25519/-/noble-ed25519-1.2.6.tgz#a55b75c61da000498abb43ffd81caaa370bfed22"
+  integrity sha512-zfnWqg9FVMp8CnzUpAjbt1nDXpDjCvxYiCXdnW1mY8zQHw/6twUlkFm14VPdojVzc0kcd+i9zT79+26GcNbsuQ==
+
+noble-secp256k1@^1.2.10:
+  version "1.2.14"
+  resolved "https://registry.yarnpkg.com/noble-secp256k1/-/noble-secp256k1-1.2.14.tgz#39429c941d51211ca40161569cee03e61d72599e"
+  integrity sha512-GSCXyoZBUaaPwVWdYncMEmzlSUjF9J/YeEHpklYJCyg8wPuJP3NzDx0BkiwArzINkdX2HJHvUJhL6vVWPOQQcg==
+
+node-addon-api@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
+  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
 
 node-fetch@^2.6.2:
   version "2.6.5"
@@ -570,6 +752,11 @@ node-fetch@^2.6.2:
   integrity sha512-mmlIVHJEu5rnIxgEgez6b9GgWXbkZj5YZ7fx+2r94a2E+Uirsp6HsPTPlomfdHtpt/B0cdKviwkoaM6pyvUOpQ==
   dependencies:
     whatwg-url "^5.0.0"
+
+node-forge@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz#32dea2afb3e9926f02ee5ce8794902691a676bf3"
+  integrity sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==
 
 node-gyp-build@^4.2.0:
   version "4.3.0"
@@ -600,12 +787,50 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
+peer-id@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/peer-id/-/peer-id-0.15.3.tgz#c093486bcc11399ba63672990382946cfcf0e6f3"
+  integrity sha512-pass5tk6Fbaz7PTD/3fJg2KWqaproHY0B0Ki8GQMEuMjkoLRcS2Vqt9yy6ob/+8uGBmWjRLtbMhaLV4HTyMDfw==
+  dependencies:
+    class-is "^1.1.0"
+    libp2p-crypto "^0.19.0"
+    minimist "^1.2.5"
+    multiformats "^9.4.5"
+    protobufjs "^6.10.2"
+    uint8arrays "^3.0.0"
+
+pem-jwk@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-2.0.0.tgz#1c5bb264612fc391340907f5c1de60c06d22f085"
+  integrity sha512-rFxu7rVoHgQ5H9YsP50dDWf0rHjreVA2z0yPiWr5WdH/UHb29hKtF7h6l8vNd1cbYR1t0QL+JKhW55a2ZV4KtA==
+  dependencies:
+    asn1.js "^5.0.1"
+
 prettier@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
   integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
 
-readable-stream@^3.6.0:
+protobufjs@^6.10.2, protobufjs@^6.11.2:
+  version "6.11.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
+  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.1"
+    "@types/node" ">=13.7.0"
+    long "^4.0.0"
+
+readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
@@ -649,10 +874,24 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@^5.2.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+safer-buffer@^2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
+  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+
 scryptsy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz#8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790"
   integrity sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==
+
+secp256k1@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz#15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1"
+  integrity sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==
+  dependencies:
+    elliptic "^6.5.2"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -726,6 +965,21 @@ typescript@^4.1.5:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
   integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+
+uint8arrays@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.0.0.tgz#260869efb8422418b6f04e3fac73a3908175c63b"
+  integrity sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==
+  dependencies:
+    multiformats "^9.4.2"
+
+ursa-optional@^0.10.1:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/ursa-optional/-/ursa-optional-0.10.2.tgz#bd74e7d60289c22ac2a69a3c8dea5eb2817f9681"
+  integrity sha512-TKdwuLboBn7M34RcvVTuQyhvrA8gYKapuVdm0nBP0mnBc7oECOfUQZrY91cefL3/nm64ZyrejSRrhTVdX7NG/A==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.14.2"
 
 utf-8-validate@^5.0.2:
   version "5.0.6"

--- a/yarn.nix
+++ b/yarn.nix
@@ -1,4 +1,4 @@
-{ fetchurl, fetchgit, linkFarm, runCommand, gnutar }: rec {
+{ fetchurl, fetchgit, linkFarm, runCommandNoCC, gnutar }: rec {
   offline_cache = linkFarm "offline" packages;
   packages = [
     {
@@ -162,11 +162,99 @@
       };
     }
     {
+      name = "_protobufjs_aspromise___aspromise_1.1.2.tgz";
+      path = fetchurl {
+        name = "_protobufjs_aspromise___aspromise_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz";
+        sha1 = "9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf";
+      };
+    }
+    {
+      name = "_protobufjs_base64___base64_1.1.2.tgz";
+      path = fetchurl {
+        name = "_protobufjs_base64___base64_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz";
+        sha1 = "4c85730e59b9a1f1f349047dbf24296034bb2735";
+      };
+    }
+    {
+      name = "_protobufjs_codegen___codegen_2.0.4.tgz";
+      path = fetchurl {
+        name = "_protobufjs_codegen___codegen_2.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz";
+        sha1 = "7ef37f0d010fb028ad1ad59722e506d9262815cb";
+      };
+    }
+    {
+      name = "_protobufjs_eventemitter___eventemitter_1.1.0.tgz";
+      path = fetchurl {
+        name = "_protobufjs_eventemitter___eventemitter_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz";
+        sha1 = "355cbc98bafad5978f9ed095f397621f1d066b70";
+      };
+    }
+    {
+      name = "_protobufjs_fetch___fetch_1.1.0.tgz";
+      path = fetchurl {
+        name = "_protobufjs_fetch___fetch_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz";
+        sha1 = "ba99fb598614af65700c1619ff06d454b0d84c45";
+      };
+    }
+    {
+      name = "_protobufjs_float___float_1.0.2.tgz";
+      path = fetchurl {
+        name = "_protobufjs_float___float_1.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz";
+        sha1 = "5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1";
+      };
+    }
+    {
+      name = "_protobufjs_inquire___inquire_1.1.0.tgz";
+      path = fetchurl {
+        name = "_protobufjs_inquire___inquire_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz";
+        sha1 = "ff200e3e7cf2429e2dcafc1140828e8cc638f089";
+      };
+    }
+    {
+      name = "_protobufjs_path___path_1.1.2.tgz";
+      path = fetchurl {
+        name = "_protobufjs_path___path_1.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz";
+        sha1 = "6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d";
+      };
+    }
+    {
+      name = "_protobufjs_pool___pool_1.1.0.tgz";
+      path = fetchurl {
+        name = "_protobufjs_pool___pool_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz";
+        sha1 = "09fd15f2d6d3abfa9b65bc366506d6ad7846ff54";
+      };
+    }
+    {
+      name = "_protobufjs_utf8___utf8_1.1.0.tgz";
+      path = fetchurl {
+        name = "_protobufjs_utf8___utf8_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz";
+        sha1 = "a777360b5b39a1a2e5106f8e858f2fd2d060c570";
+      };
+    }
+    {
       name = "_types_bn.js___bn.js_4.11.6.tgz";
       path = fetchurl {
         name = "_types_bn.js___bn.js_4.11.6.tgz";
         url  = "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz";
         sha1 = "c306c70d9358aaea33cd4eda092a742b9505967c";
+      };
+    }
+    {
+      name = "_types_long___long_4.0.1.tgz";
+      path = fetchurl {
+        name = "_types_long___long_4.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz";
+        sha1 = "459c65fa1867dafe6a8f322c4c51695663cc55e9";
       };
     }
     {
@@ -183,6 +271,14 @@
         name = "_types_node___node_16.10.3.tgz";
         url  = "https://registry.yarnpkg.com/@types/node/-/node-16.10.3.tgz";
         sha1 = "7a8f2838603ea314d1d22bb3171d899e15c57bd5";
+      };
+    }
+    {
+      name = "_types_node___node_16.11.8.tgz";
+      path = fetchurl {
+        name = "_types_node___node_16.11.8.tgz";
+        url  = "https://registry.yarnpkg.com/@types/node/-/node-16.11.8.tgz";
+        sha1 = "a1aeb23f0aa33cb111e64ccaa1687b2ae0423b69";
       };
     }
     {
@@ -210,6 +306,14 @@
       };
     }
     {
+      name = "asn1.js___asn1.js_5.4.1.tgz";
+      path = fetchurl {
+        name = "asn1.js___asn1.js_5.4.1.tgz";
+        url  = "https://registry.yarnpkg.com/asn1.js/-/asn1.js-5.4.1.tgz";
+        sha1 = "11a980b84ebb91781ce35b0fdc2ee294e3783f07";
+      };
+    }
+    {
       name = "asynckit___asynckit_0.4.0.tgz";
       path = fetchurl {
         name = "asynckit___asynckit_0.4.0.tgz";
@@ -231,6 +335,14 @@
         name = "base64_js___base64_js_1.5.1.tgz";
         url  = "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz";
         sha1 = "1b1b440160a5bf7ad40b650f095963481903930a";
+      };
+    }
+    {
+      name = "bindings___bindings_1.5.0.tgz";
+      path = fetchurl {
+        name = "bindings___bindings_1.5.0.tgz";
+        url  = "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz";
+        sha1 = "10353c9e945334bc0511a6d90b38fbc7c9c504df";
       };
     }
     {
@@ -287,6 +399,14 @@
         name = "cipher_base___cipher_base_1.0.4.tgz";
         url  = "https://registry.yarnpkg.com/cipher-base/-/cipher-base-1.0.4.tgz";
         sha1 = "8760e4ecc272f4c363532f926d874aae2c1397de";
+      };
+    }
+    {
+      name = "class_is___class_is_1.1.0.tgz";
+      path = fetchurl {
+        name = "class_is___class_is_1.1.0.tgz";
+        url  = "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz";
+        sha1 = "9d3c0fba0440d211d843cec3dedfa48055005825";
       };
     }
     {
@@ -394,6 +514,14 @@
       };
     }
     {
+      name = "err_code___err_code_3.0.1.tgz";
+      path = fetchurl {
+        name = "err_code___err_code_3.0.1.tgz";
+        url  = "https://registry.yarnpkg.com/err-code/-/err-code-3.0.1.tgz";
+        sha1 = "a444c7b992705f2b120ee320b09972eef331c920";
+      };
+    }
+    {
       name = "es5_ext___es5_ext_0.10.53.tgz";
       path = fetchurl {
         name = "es5_ext___es5_ext_0.10.53.tgz";
@@ -426,11 +554,27 @@
       };
     }
     {
+      name = "events___events_3.3.0.tgz";
+      path = fetchurl {
+        name = "events___events_3.3.0.tgz";
+        url  = "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz";
+        sha1 = "31a95ad0a924e2d2c419a813aeb2c4e878ea7400";
+      };
+    }
+    {
       name = "ext___ext_1.6.0.tgz";
       path = fetchurl {
         name = "ext___ext_1.6.0.tgz";
         url  = "https://registry.yarnpkg.com/ext/-/ext-1.6.0.tgz";
         sha1 = "3871d50641e874cc172e2b53f919842d19db4c52";
+      };
+    }
+    {
+      name = "file_uri_to_path___file_uri_to_path_1.0.0.tgz";
+      path = fetchurl {
+        name = "file_uri_to_path___file_uri_to_path_1.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz";
+        sha1 = "553a7b8446ff6f684359c445f1e37a05dacc33dd";
       };
     }
     {
@@ -522,6 +666,14 @@
       };
     }
     {
+      name = "iso_random_stream___iso_random_stream_2.0.0.tgz";
+      path = fetchurl {
+        name = "iso_random_stream___iso_random_stream_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-2.0.0.tgz";
+        sha1 = "3f0118166d5443148bbc134345fb100002ad0f1d";
+      };
+    }
+    {
       name = "js_sha3___js_sha3_0.8.0.tgz";
       path = fetchurl {
         name = "js_sha3___js_sha3_0.8.0.tgz";
@@ -530,11 +682,43 @@
       };
     }
     {
+      name = "keypair___keypair_1.0.4.tgz";
+      path = fetchurl {
+        name = "keypair___keypair_1.0.4.tgz";
+        url  = "https://registry.yarnpkg.com/keypair/-/keypair-1.0.4.tgz";
+        sha1 = "a749a45f388593f3950f18b3757d32a93bd8ce83";
+      };
+    }
+    {
+      name = "libp2p_crypto___libp2p_crypto_0.19.7.tgz";
+      path = fetchurl {
+        name = "libp2p_crypto___libp2p_crypto_0.19.7.tgz";
+        url  = "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.19.7.tgz";
+        sha1 = "e96a95bd430e672a695209fe0fbd2bcbd348bc35";
+      };
+    }
+    {
+      name = "libp2p_crypto___libp2p_crypto_0.20.0.tgz";
+      path = fetchurl {
+        name = "libp2p_crypto___libp2p_crypto_0.20.0.tgz";
+        url  = "https://registry.yarnpkg.com/libp2p-crypto/-/libp2p-crypto-0.20.0.tgz";
+        sha1 = "3881ccff5f1f51f48c74050d685535fb1a728488";
+      };
+    }
+    {
       name = "locate_path___locate_path_5.0.0.tgz";
       path = fetchurl {
         name = "locate_path___locate_path_5.0.0.tgz";
         url  = "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz";
         sha1 = "1afba396afd676a6d42504d0a67a3a7eb9f62aa0";
+      };
+    }
+    {
+      name = "long___long_4.0.0.tgz";
+      path = fetchurl {
+        name = "long___long_4.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz";
+        sha1 = "9a7b71cfb7d361a194ea555241c92f7468d5bf28";
       };
     }
     {
@@ -578,11 +762,35 @@
       };
     }
     {
+      name = "minimist___minimist_1.2.5.tgz";
+      path = fetchurl {
+        name = "minimist___minimist_1.2.5.tgz";
+        url  = "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz";
+        sha1 = "67d66014b66a6a8aaa0c083c5fd58df4e4e97602";
+      };
+    }
+    {
       name = "ms___ms_2.0.0.tgz";
       path = fetchurl {
         name = "ms___ms_2.0.0.tgz";
         url  = "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz";
         sha1 = "5608aeadfc00be6c2901df5f9861788de0d597c8";
+      };
+    }
+    {
+      name = "multiformats___multiformats_9.4.10.tgz";
+      path = fetchurl {
+        name = "multiformats___multiformats_9.4.10.tgz";
+        url  = "https://registry.yarnpkg.com/multiformats/-/multiformats-9.4.10.tgz";
+        sha1 = "d654d06b28cc066506e4e59b246d65267fb6b93b";
+      };
+    }
+    {
+      name = "nan___nan_2.15.0.tgz";
+      path = fetchurl {
+        name = "nan___nan_2.15.0.tgz";
+        url  = "https://registry.yarnpkg.com/nan/-/nan-2.15.0.tgz";
+        sha1 = "3f34a473ff18e15c1b5626b62903b5ad6e665fee";
       };
     }
     {
@@ -594,11 +802,43 @@
       };
     }
     {
+      name = "noble_ed25519___noble_ed25519_1.2.6.tgz";
+      path = fetchurl {
+        name = "noble_ed25519___noble_ed25519_1.2.6.tgz";
+        url  = "https://registry.yarnpkg.com/noble-ed25519/-/noble-ed25519-1.2.6.tgz";
+        sha1 = "a55b75c61da000498abb43ffd81caaa370bfed22";
+      };
+    }
+    {
+      name = "noble_secp256k1___noble_secp256k1_1.2.14.tgz";
+      path = fetchurl {
+        name = "noble_secp256k1___noble_secp256k1_1.2.14.tgz";
+        url  = "https://registry.yarnpkg.com/noble-secp256k1/-/noble-secp256k1-1.2.14.tgz";
+        sha1 = "39429c941d51211ca40161569cee03e61d72599e";
+      };
+    }
+    {
+      name = "node_addon_api___node_addon_api_2.0.2.tgz";
+      path = fetchurl {
+        name = "node_addon_api___node_addon_api_2.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz";
+        sha1 = "432cfa82962ce494b132e9d72a15b29f71ff5d32";
+      };
+    }
+    {
       name = "node_fetch___node_fetch_2.6.5.tgz";
       path = fetchurl {
         name = "node_fetch___node_fetch_2.6.5.tgz";
         url  = "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.5.tgz";
         sha1 = "42735537d7f080a7e5f78b6c549b7146be1742fd";
+      };
+    }
+    {
+      name = "node_forge___node_forge_0.10.0.tgz";
+      path = fetchurl {
+        name = "node_forge___node_forge_0.10.0.tgz";
+        url  = "https://registry.yarnpkg.com/node-forge/-/node-forge-0.10.0.tgz";
+        sha1 = "32dea2afb3e9926f02ee5ce8794902691a676bf3";
       };
     }
     {
@@ -642,11 +882,35 @@
       };
     }
     {
+      name = "peer_id___peer_id_0.15.3.tgz";
+      path = fetchurl {
+        name = "peer_id___peer_id_0.15.3.tgz";
+        url  = "https://registry.yarnpkg.com/peer-id/-/peer-id-0.15.3.tgz";
+        sha1 = "c093486bcc11399ba63672990382946cfcf0e6f3";
+      };
+    }
+    {
+      name = "pem_jwk___pem_jwk_2.0.0.tgz";
+      path = fetchurl {
+        name = "pem_jwk___pem_jwk_2.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/pem-jwk/-/pem-jwk-2.0.0.tgz";
+        sha1 = "1c5bb264612fc391340907f5c1de60c06d22f085";
+      };
+    }
+    {
       name = "prettier___prettier_2.4.1.tgz";
       path = fetchurl {
         name = "prettier___prettier_2.4.1.tgz";
         url  = "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz";
         sha1 = "671e11c89c14a4cfc876ce564106c4a6726c9f5c";
+      };
+    }
+    {
+      name = "protobufjs___protobufjs_6.11.2.tgz";
+      path = fetchurl {
+        name = "protobufjs___protobufjs_6.11.2.tgz";
+        url  = "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz";
+        sha1 = "de39fabd4ed32beaa08e9bb1e30d08544c1edf8b";
       };
     }
     {
@@ -706,11 +970,27 @@
       };
     }
     {
+      name = "safer_buffer___safer_buffer_2.1.2.tgz";
+      path = fetchurl {
+        name = "safer_buffer___safer_buffer_2.1.2.tgz";
+        url  = "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz";
+        sha1 = "44fa161b0187b9549dd84bb91802f9bd8385cd6a";
+      };
+    }
+    {
       name = "scryptsy___scryptsy_2.1.0.tgz";
       path = fetchurl {
         name = "scryptsy___scryptsy_2.1.0.tgz";
         url  = "https://registry.yarnpkg.com/scryptsy/-/scryptsy-2.1.0.tgz";
         sha1 = "8d1e8d0c025b58fdd25b6fa9a0dc905ee8faa790";
+      };
+    }
+    {
+      name = "secp256k1___secp256k1_4.0.2.tgz";
+      path = fetchurl {
+        name = "secp256k1___secp256k1_4.0.2.tgz";
+        url  = "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.2.tgz";
+        sha1 = "15dd57d0f0b9fdb54ac1fa1694f40e5e9a54f4a1";
       };
     }
     {
@@ -807,6 +1087,22 @@
         name = "typescript___typescript_4.4.3.tgz";
         url  = "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz";
         sha1 = "bdc5407caa2b109efd4f82fe130656f977a29324";
+      };
+    }
+    {
+      name = "uint8arrays___uint8arrays_3.0.0.tgz";
+      path = fetchurl {
+        name = "uint8arrays___uint8arrays_3.0.0.tgz";
+        url  = "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.0.0.tgz";
+        sha1 = "260869efb8422418b6f04e3fac73a3908175c63b";
+      };
+    }
+    {
+      name = "ursa_optional___ursa_optional_0.10.2.tgz";
+      path = fetchurl {
+        name = "ursa_optional___ursa_optional_0.10.2.tgz";
+        url  = "https://registry.yarnpkg.com/ursa-optional/-/ursa-optional-0.10.2.tgz";
+        sha1 = "bd74e7d60289c22ac2a69a3c8dea5eb2817f9681";
       };
     }
     {


### PR DESCRIPTION
For unknown reasons my nodes refuse connecting to each other. This is not only me though apprently https://github.com/paritytech/polkadot-launch/issues/77. There was an attempt to fix that by @JesseAbram, however, it never really landed.

So I just went ahead and implemented @bkchr's suggestion (at least my interpretation of it): do not wait for the node to start up and just embed the keys into the chainspec.

Specifically, the config gets a new parameter for a node: `nodeKey`. This is a 32 byte hex encoded string, the same as you would put in `--node-key` parameter when running a substrate node. In fact, we pass the node key with that flag upon spawning the validator nodes. In case the config does not specify node key, we just generate it. Then that nodeKey we construct a peer id, and use that to generate the boot nodes list. The boot nodes list assumes localhost/127.0.0.1.

Since this PR adds new dependencies, I also updated the yarn.nix.