### PR TITLE
Update README.md to reflect Apple M1 ARM users

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm i polkadot-launch -g
 To use polkadot-launch, you need to have binary files for a `polkadot` relay chain and a
 `polkadot-collator` in the bin folder.
 
+> If you are on an Apple M1 ARM chip, make sure you are using the `stable-aarch64-apple-darwin` toolchain to compile the binaries.
+
 You can generate these files by cloning the `rococo-v1` branch of these projects in the same root as the polkadot-launch repo
 and building them with the specific flags below:
 


### PR DESCRIPTION
Using `stable-aarch64-apple-darwin` toolchain to compile the binaries on an Apple M1 ARM system works.

closes #169