### PR TITLE
`onlyOneParachainNode` true iif the number of nodes is 1

### DIFF
--- a/src/runner.ts
+++ b/src/runner.ts
@@ -143,7 +143,7 @@ export async function run(config_dir: string, rawConfig: LaunchConfig) {
 				flags,
 				chain: paraChain,
 				basePath,
-				onlyOneParachainNode: config.parachains.length === 1,
+				onlyOneParachainNode: parachain.nodes.length === 1,
 			});
 		}
 


### PR DESCRIPTION
Right now the behavior of polkadot-launch doesn't correspond with the desired behaviour.

AURA requires a minimum of 2 nodes in order to produce blocks. This can be forced when running one node by adding the flag
`--force-authoring`.
This flag should be only added in case the para will be running with just one node. (Even though no harm is done by adding it when there is more than one).

 What we had:
 ```
 onlyOneParachainNode: config.parachains.length === 1, // This checks the number of parachains to be run.
 ```
 We are adding this flag in case there are more than one parachain, independentlyof the number of nodes to be launch per parachain. 
 
 This PR propose the following fix:
 ```
 onlyOneParachainNode: parachain.nodes.length === 1,  // Check the number of nodes in every parachain.
 ```