### PR TITLE
increase exec  buffer size

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -156,7 +156,7 @@ export async function exportGenesisWasm(
 
 	// wasm files are typically large and `exec` requires us to supply the maximum buffer size in
 	// advance. Hopefully, this generous limit will be enough.
-	let opts = { maxBuffer: 10 * 1024 * 1024 };
+	let opts = { maxBuffer: 32 * 1024 * 1024 };
 	verbose(bin, args);
 	let { stdout, stderr } = await execFile(bin, args, opts);
 	if (stderr) {


### PR DESCRIPTION
for the case of uncompressed wasm
because we speed up and simplify builds for devs repl
and we do not care size of wasm
and I get error
```
runtime-tests-composable-1 | ⚙ Updating Relay Chain Genesis Configuration
runtime-tests-composable-1 | ⚠ Bad Genesis Configuration [ validation_upgrade_frequency: 2 ]
runtime-tests-composable-1 | ✓ Updated Genesis Configuration [ validation_upgrade_delay: 2 ]
runtime-tests-composable-1 |
runtime-tests-composable-1 | ⛓ Adding Genesis Parachains
runtime-tests-composable-1 |  /apps/composable/target/release/composable export-genesis-state --chain=dali-dev 
runtime-tests-composable-1 |  /apps/composable/target/release/composable export-genesis-wasm --chain=dali-dev 
runtime-tests-composable-1 | RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stdout maxBuffer length exceeded
runtime-tests-composable-1 | at new NodeError (node:internal/errors:372:5)
runtime-tests-composable-1 | at Socket.onChildStdout (node:child_process:461:14)
runtime-tests-composable-1 | at Socket.emit (node:events:527:28)
runtime-tests-composable-1 | at addChunk (node:internal/streams/readable:324:12)
runtime-tests-composable-1 | at readableAddChunk (node:internal/streams/readable:293:11)
runtime-tests-composable-1 | at Socket.Readable.push (node:internal/streams/readable:234:10)
runtime-tests-composable-1 | at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) {
runtime-tests-composable-1 | code: 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER',
runtime-tests-composable-1 | cmd: '/apps/composable/target/release/composable export-genesis-wasm --chain=dali-dev',
runtime-tests-composable-1 | stdout: '0x0061736d0100000001850a8c0160057f7f7f7f7f0060017f017f60017f0060047f7f7f7f0060047f7f7f7f017f60067f7f7f7f7f7f0060057f7f7f7f7f017f60077f7f7f7f7f7f7f0060057f7f7f7e7e017f60067f7f7f7f7e7e0060057f7f7f7e7e006000017e6000017f60037f7f7f0
````


our uncompressed sizes are 
<img width="527" alt="image" src="https://user-images.githubusercontent.com/757125/183242044-6f6d476f-7735-4dd6-9d14-26db0e45eb6e.png">
